### PR TITLE
Add the disassembler_riscv32.hpp into src/hotspot/cpu/riscv32/

### DIFF
--- a/src/hotspot/cpu/riscv32/disassembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/disassembler_riscv32.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation, * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV32_VM_DISASSEMBLER_RISCV32_HPP
+#define CPU_RISCV32_VM_DISASSEMBLER_RISCV32_HPP
+
+  static int pd_instruction_alignment() {
+    return 1;
+  }
+
+  static const char* pd_cpu_opts() {
+    return "";
+  }
+
+#endif // CPU_RISCV32_VM_DISASSEMBLER_RISCV32_HPP


### PR DESCRIPTION
Add the disassembler_riscv32.hpp, it is same with the disassembler_riscv64.hpp of BishengJDK, just changed the 64 text in the file name and define.