### PR TITLE
remove the is_valid_riscv32_address()

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -2906,7 +2906,6 @@ void MacroAssembler::la_patchable(Register reg1, const Address &dest, int32_t &o
   long offset_low = dest_address - low_address;
   long offset_high = dest_address - high_address;
 
-  assert(is_valid_riscv32_address(dest.target()), "bad address");
   assert(dest.getMode() == Address::literal, "la_patchable must be applied to a literal address");
 
   InstructionMark im(this);

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -791,12 +791,6 @@ private:
   void load_prototype_header(Register dst, Register src);
   void repne_scan(Register addr, Register value, Register count, Register temp);
 
-  // Return true if an addres is within the 32-bit Riscv32 address
-  // space. According the 4.1.12 of riscv-privileged-20190608.
-  bool is_valid_riscv32_address(address addr) {
-    return ((uintptr_t)addr >> 32) == 0;
-  }
-
   void ld_constant(Register dest, const Address &const_addr) {
     if (NearCpool) {
       lw(dest, const_addr);


### PR DESCRIPTION
The is_valid_riscv32_address() is useless in the rv32g model. Because the address of rv32g is always 32 bit.
The rv32g use the sv32 mode.