### PR TITLE
Fix li32 in assembler and macroAssembler moudle

### DIFF
--- a/src/hotspot/cpu/riscv32/assembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.cpp
@@ -581,23 +581,6 @@ void Assembler::sub(Register Rd, Register Rn, int32_t decrement, Register temp) 
 }
 
 void Assembler::li(Register Rd, int32_t imm) {
-  // int32_t is in range 0x8000 0000 ~ 0x7fff ffff
-  int shift = 12;
-  int64_t upper = imm, lower = imm;
-  // Split imm to a lower 12-bit sign-extended part and the remainder, because addi will sign-extend the lower imm.
-  lower = ((int32_t)imm << 20) >> 20;
-  upper -= lower;
-  Register hi_Rd = zr;
-  if (upper != 0) {
-    lui(Rd, (int32_t)upper);
-    hi_Rd = Rd;
-  }
-  if (lower != 0 || hi_Rd == zr) {
-    addi(Rd, hi_Rd, lower);
-  }
-}
-
-void Assembler::li32(Register Rd, int32_t imm) {
   // int32_t is in range 0x8000 0000 ~ 0x7fff ffff, and imm[31] is the sign bit
   int64_t upper = imm, lower = imm;
   lower = (imm << 20) >> 20;

--- a/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
@@ -297,8 +297,7 @@ public:
     }
   }
 
-  void li(Register Rd, int32_t imm);  // optimized load immediate
-  void li32(Register Rd, int32_t imm);
+  void li(Register Rd, int32_t imm);
   void movptr(Register Rd, address addr);
   void movptr_with_offset(Register Rd, address addr, int32_t &offset);
   void movptr(Register Rd, uintptr_t imm64);

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -3004,8 +3004,7 @@ void  MacroAssembler::set_narrow_oop(Register dst, jobject obj) {
   InstructionMark im(this);
   RelocationHolder rspec = oop_Relocation::spec(oop_index);
   code_section()->relocate(inst_mark(), rspec);
-  li32(dst, 0xDEADBEEF);
-  clear_upper_bits(dst, 32); // clear upper 32bit, do not sign extend.
+  li(dst, 0xDEADBEEF);
 }
 
 void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
@@ -3018,8 +3017,7 @@ void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
   RelocationHolder rspec = metadata_Relocation::spec(index);
   code_section()->relocate(inst_mark(), rspec);
   narrowKlass nk = Klass::encode_klass(k);
-  li32(dst, nk);
-  clear_upper_bits(dst, 32); // clear upper 32bit, do not sign extend.
+  li(dst, nk);
 }
 
 // Maybe emit a call via a trampoline.  If the code cache is small


### PR DESCRIPTION
Remove the declaration of li32 in assembler_riscv32.hpp.
Remove the function of Assembler::li32 in assembler_riscv32.cpp.
Rename the function of li32 to li and remove operation of clear upper 32bit in macroAssembler_riscv32.cpp.