### PR TITLE
Fix the lwu error in jniFastGetField_riscv32.cpp

### DIFF
--- a/src/hotspot/cpu/riscv32/jniFastGetField_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/jniFastGetField_riscv32.cpp
@@ -79,7 +79,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   __ addi(rcounter_addr, rcounter_addr, offset);
 
   Address safepoint_counter_addr(rcounter_addr, 0);
-  __ lwu(rcounter, safepoint_counter_addr);
+  __ lw(rcounter, safepoint_counter_addr);
   // An even value means there are no ongoing safepoint operations
   __ andi(t0, rcounter, 1);
   __ bnez(t0, slow);


### PR DESCRIPTION
Update the jniFastGetField_riscv32.cpp: lwu->lw.

Update the macroAssembler_riscv32.cpp: ld->lw, sd->sw, addw->add, addiw->addi, subw->sub, lwu->lw;
also update the 0x%016lx in debug32() to 0x%016x.