### PR TITLE
Rv32g dev shiningning fix native inst

### DIFF
--- a/src/hotspot/cpu/riscv32/nativeInst_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/nativeInst_riscv32.hpp
@@ -2,6 +2,7 @@
  * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2018, Red Hat Inc. All rights reserved.
  * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2021, Institute of Software, Chinese Academy of Sciences. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -380,7 +381,7 @@ inline NativeMovConstReg* nativeMovConstReg_before(address addr) {
   return test;
 }
 
-/*// RISCV64 should not use C1 runtime patching, so just leave NativeMovRegMem Unimplemented.
+// RISCV32 should not use C1 runtime patching, so just leave NativeMovRegMem Unimplemented.
 class NativeMovRegMem: public NativeInstruction {
  public:
   int instruction_start() const {
@@ -414,7 +415,7 @@ class NativeMovRegMem: public NativeInstruction {
 inline NativeMovRegMem* nativeMovRegMem_at (address addr) {
   Unimplemented();
   return NULL;
-}*/
+}
 
 class NativeJump: public NativeInstruction {
  public:

--- a/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
@@ -40,7 +40,7 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/vframeArray.hpp"
 #include "utilities/align.hpp"
-#include "vmreg_riscv64.inline.hpp"
+#include "vmreg_riscv32.inline.hpp"
 #ifdef COMPILER1
 #include "c1/c1_Runtime1.hpp"
 #endif

--- a/src/hotspot/share/runtime/vm_version.cpp
+++ b/src/hotspot/share/runtime/vm_version.cpp
@@ -99,8 +99,13 @@ bool Abstract_VM_Version::_parallel_worker_threads_initialized = false;
   #ifdef ZERO
     #define VMTYPE "Zero"
   #else // ZERO
-     #define VMTYPE COMPILER1_PRESENT("Client")   \
-                    COMPILER2_PRESENT("Server")
+     #ifdef COMPILER2
+        #define VMTYPE "Server"
+     #elif defined(COMPILER1)
+        #define VMTYPE "Client"
+     #else
+        #define VMTYPE "Core"
+     #endif // COMPILER2
   #endif // ZERO
   #endif // TIERED
 #endif
@@ -197,7 +202,8 @@ const char* Abstract_VM_Version::jre_release_version() {
                  IA32_ONLY("x86")                \
                  IA64_ONLY("ia64")               \
                  S390_ONLY("s390")               \
-                 SPARC_ONLY("sparc")
+                 SPARC_ONLY("sparc")             \
+		 RISCV32_ONLY("riscv32")
 #endif // !ZERO
 #endif // !CPU
 

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -587,6 +587,22 @@
 #define NOT_AARCH64(code) code
 #endif
 
+#ifdef RISCV32
+#define RISCV32_ONLY(code) code
+#define NOT_RISCV32(code)
+#define NO_FLAG_REG
+#define NO_FLAGREG_ONLY(code) code
+#define HAS_FLAGREG_ONLY(code)
+#define NO_FLAGREG_ONLY_ARG(arg) arg,
+#else
+#define RISCV32_ONLY(code)
+#define NOT_RISCV32(code) code
+#define HAS_FLAG_REG
+#define NO_FLAGREG_ONLY(code)
+#define HAS_FLAGREG_ONLY(code) code
+#define NO_FLAGREG_ONLY_ARG(arg)
+#endif
+
 #ifdef VM_LITTLE_ENDIAN
 #define LITTLE_ENDIAN_ONLY(code) code
 #define BIG_ENDIAN_ONLY(code)


### PR DESCRIPTION
Fix 'NativeMovRegMem has not been declared' errors.
Fix 'RISCV32_ONLY was not declared' error.
Fix 'sharedRuntime_riscv32.cpp:43:10: fatal error: vmreg_riscv64.inline.hpp: No such file or directory' error.