### PR TITLE
Rv32g dev zdl fix no match function or member

### DIFF
--- a/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
@@ -562,7 +562,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
       }
     } else {
       if (!r_2->is_valid()) {
-        __ lw(r_1->as_FloatRegister(), Address(esp, ld_off));
+        __ flw(r_1->as_FloatRegister(), Address(esp, ld_off));
       } else {
         __ fld(r_1->as_FloatRegister(), Address(esp, next_off));
       }

--- a/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
@@ -580,7 +580,7 @@ class StubGenerator: public StubCodeGenerator {
 #endif
     BLOCK_COMMENT("call MacroAssembler::debug");
     int32_t offset = 0;
-    __ movptr_with_offset(t0, CAST_FROM_FN_PTR(address, MacroAssembler::debug64), offset);
+    __ movptr_with_offset(t0, CAST_FROM_FN_PTR(address, MacroAssembler::debug32), offset);
     __ jalr(x1, t0, offset);
 
     return start;
@@ -1956,7 +1956,7 @@ class StubGenerator: public StubCodeGenerator {
     //
     //  Fill large chunks
     //
-    __ srliw(cnt_words, count, 3 - shift); // number of words
+    __ srli(cnt_words, count, 3 - shift); // number of words
 
     // 32 bit -> 64 bit
     __ andi(value, value, 0xffffffff);

--- a/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
@@ -1748,7 +1748,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   __ lhu(t0, Address(t0, ConstMethod::max_stack_offset()));
   __ add(t0, t0, frame::interpreter_frame_monitor_size() + 4);
   __ lw(t1, Address(fp, frame::interpreter_frame_initial_sp_offset * wordSize));
-  __ slliw(t0, t0, 3);
+  __ slli(t0, t0, 3);
   __ sub(t0, t1, t0);
   __ andi(sp, t0, -16);
 

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -305,7 +305,7 @@ void TemplateTable::sipush()
   transition(vtos, itos);
   __ load_unsigned_short(x10, at_bcp(1));
   __ grevw(x10, x10);
-  __ sraiw(x10, x10, 16);
+  __ srai(x10, x10, 16);
 }
 
 void TemplateTable::ldc(bool wide)
@@ -2205,7 +2205,7 @@ void TemplateTable::fast_binaryswitch() {
     Label loop;
     __ bind(loop);
     __ add(h, i, j);                           // h = i + j
-    __ srliw(h, h, 1);                          // h = (i + j) >> 1
+    __ srli(h, h, 1);                          // h = (i + j) >> 1
     // if [key < array[h].fast_match()]
     // then [j = h]
     // else [i = h]


### PR DESCRIPTION
Fix typo of 'lw' in src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp.
Fix error in src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp.
Fix error: 'class InterpreterMacroAssembler' has no member named 'slliw' error in src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
Fix error: 'class InterpreterMacroAssembler' has no member named 'xx' in src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
