### PR TITLE
 Fix the error of get_lwp_regs()

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc.h
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc.h
@@ -74,6 +74,8 @@ combination of ptrace and /proc calls.
 #elif defined(arm)
 #include <asm/ptrace.h>
 #define user_regs_struct  pt_regs
+#elif defined(riscv32)
+#include <asm/ptrace.h>
 #endif
 
 // This C bool type must be int for compatibility with Linux calls and


### PR DESCRIPTION
Add the elif defined(riscv32) into the /src/jdk.hotspot.agent/linux/native/libsaproc/libproc.h.
After this fix, the interpreter can compiled success.