### PR TITLE
Fix unused template in atomic_linux_riscv32.hpp and os_linux_riscv32

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv32/atomic_linux_riscv32.hpp
+++ b/src/hotspot/os_cpu/linux_riscv32/atomic_linux_riscv32.hpp
@@ -112,19 +112,11 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T exchange_value,
 
 template<>
 template<typename T>
-inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {
-  STATIC_ASSERT(8 == sizeof(T));
-  return PrimitiveConversions::cast<T>(
-    (*os::atomic_load_long_func)(reinterpret_cast<const volatile int64_t*>(src)));
-}
+inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {}
 
 template<>
 template<typename T>
 inline void Atomic::PlatformStore<8>::operator()(T store_value,
-                                                 T volatile* dest) const {
-  STATIC_ASSERT(8 == sizeof(T));
-  (*os::atomic_store_long_func)(
-    PrimitiveConversions::cast<int64_t>(store_value), reinterpret_cast<volatile int64_t*>(dest));
-}
+                                                 T volatile* dest) const {}
 
 #endif // OS_CPU_LINUX_RISCV32_VM_ATOMIC_LINUX_RISCV32_HPP

--- a/src/hotspot/os_cpu/linux_riscv32/os_linux_riscv32.cpp
+++ b/src/hotspot/os_cpu/linux_riscv32/os_linux_riscv32.cpp
@@ -621,43 +621,6 @@ bool os::is_allocatable(size_t bytes) {
   return true;
 }
 
-typedef int64_t load_long_func_t(const volatile int64_t*);
-
-load_long_func_t* os::atomic_load_long_func = os::atomic_load_long_bootstrap;
-
-int64_t os::atomic_load_long_bootstrap(const volatile int64_t* src) {
-  // try to use the stub:
-  // FIXME
-  // load_long_func_t* func = CAST_TO_FN_PTR(load_long_func_t*, StubRoutines::atomic_load_long_entry());
-
-  // if (func != NULL) {
-  //   os::atomic_load_long_func = func;
-  //   return (*func)(src);
-  // }
-  // assert(Threads::number_of_threads() == 0, "for bootstrap only");
-
-  // int64_t old_value = *src;
-  // return old_value;
-}
-
-typedef void store_long_func_t(int64_t, volatile int64_t*);
-
-store_long_func_t* os::atomic_store_long_func = os::atomic_store_long_bootstrap;
-
-void os::atomic_store_long_bootstrap(int64_t val, volatile int64_t* dest) {
-  // try to use the stub:
-  // FIXME
-  // store_long_func_t* func = CAST_TO_FN_PTR(store_long_func_t*, StubRoutines::atomic_store_long_entry());
-
-  // if (func != NULL) {
-  //   os::atomic_store_long_func = func;
-  //   return (*func)(val, dest);
-  // }
-  // assert(Threads::number_of_threads() == 0, "for bootstrap only");
-
-  // *dest = val;
-}
-
 #ifndef PRODUCT
 void os::verify_stack_alignment() {
   assert(((intptr_t)os::current_stack_pointer() & (StackAlignmentInBytes-1)) == 0, "incorrect stack alignment");

--- a/src/hotspot/os_cpu/linux_riscv32/os_linux_riscv32.hpp
+++ b/src/hotspot/os_cpu/linux_riscv32/os_linux_riscv32.hpp
@@ -59,12 +59,4 @@
                       : "memory");
   }
 
-  static int64_t atomic_load_long_bootstrap(const volatile int64_t*);
-
-  static void atomic_store_long_bootstrap(int64_t, volatile int64_t*);
-
-  static int64_t (*atomic_load_long_func)(const volatile int64_t*);
-
-  static void (*atomic_store_long_func)(int64_t, volatile int64_t*);
-
 #endif // OS_CPU_LINUX_RISCV32_VM_OS_LINUX_RISCV32_HPP


### PR DESCRIPTION
Remove unused codes about atomic_load_long_bootstrap, atomic_store_long_bootstrap, atomic_load_long_func and atomic_store_long_func from os_linux_riscv32.cpp.
Remove unused codes about atomic_load_long_bootstrap, atomic_store_long_bootstrap, atomic_load_long_func and atomic_store_long_func from os_linux_riscv32.hpp.
Remove unused codes in atomic_linux_riscv32.hpp.