### PR TITLE
Update the input param of clear_upper_bits

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -2163,7 +2163,7 @@ void MacroAssembler::load_reserved(Register addr,
       break;
     case uint32:
       lr_w(t0, addr, acquire);
-      clear_upper_bits(t0, 32);
+      clear_upper_bits(t0, 16);
       break;
     default:
       ShouldNotReachHere();
@@ -2397,7 +2397,7 @@ ATOMIC_XCHG(xchgalw, amoswap_w, Assembler::aq, Assembler::rl)
 #define ATOMIC_XCHGU(OP1, OP2)                                                       \
 void MacroAssembler::atomic_##OP1(Register prev, Register newv, Register addr) {     \
   atomic_##OP2(prev, newv, addr);                                                    \
-  clear_upper_bits(prev, 32);                                                        \
+  clear_upper_bits(prev, 16);                                                        \
   return;                                                                            \
 }
 

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -1225,7 +1225,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
         __ mv(as_Register(Matcher::_regEncode[dst_lo]),
             as_Register(Matcher::_regEncode[src_lo]));
         if (!is64 && this->ideal_reg() != Op_RegI) // zero extended for narrow oop or klass
-          __ clear_upper_bits(as_Register(Matcher::_regEncode[dst_lo]), 32);
+          __ clear_upper_bits(as_Register(Matcher::_regEncode[dst_lo]), 16);
       } else if (dst_lo_rc == rc_float) { // gpr --> fpr copy
         if (is64) {
             __ fmv_d_x(as_FloatRegister(Matcher::_regEncode[dst_lo]),
@@ -7667,7 +7667,7 @@ instruct convP2I(iRegINoSp dst, iRegP src) %{
 
   ins_encode %{
     __ mv($dst$$Register, $src$$Register);
-    __ clear_upper_bits($dst$$Register, 32);
+    __ clear_upper_bits($dst$$Register, 16);
   %}
 
   ins_pipe(ialu_reg);

--- a/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
@@ -1487,9 +1487,9 @@ class StubGenerator: public StubCodeGenerator {
     __ add(temp, length, dst_pos);
     __ bgtu(temp, t0, L_failed);
 
-    // Have to clean up high 32 bits of 'src_pos' and 'dst_pos'.
-    __ clear_upper_bits(src_pos, 32);
-    __ clear_upper_bits(dst_pos, 32);
+    // Have to clean up high 16 bits of 'src_pos' and 'dst_pos'.
+    __ clear_upper_bits(src_pos, 16);
+    __ clear_upper_bits(dst_pos, 16);
 
     BLOCK_COMMENT("arraycopy_range_checks done");
   }


### PR DESCRIPTION
The input param upper_bits still keep the 32 value, it must be 16 in rv32g. The 32 value is used in rv64g. So update it.
This patch can avoid the assert error in the clear_upper_bits() of macroAssembler_riscv32.hpp.