### PR TITLE
Remove the pseudoinstruction movptr_with_offset

### DIFF
--- a/src/hotspot/cpu/riscv32/assembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.cpp
@@ -599,7 +599,7 @@ void Assembler::li(Register Rd, int32_t imm) {
     } else {                                                       \
       assert(temp != noreg, "temp must not be empty register!");   \
       auipc(temp, (int32_t)dest);                                  \
-      jalr(REGISTER, temp, ((int32_t)dest<<20)>>20);               \
+      jalr(REGISTER, temp, ((int32_t)dest << 20) >> 20);           \
     }                                                              \
   }                                                                \
   void Assembler::NAME(Label &l, Register temp) {                  \

--- a/src/hotspot/cpu/riscv32/nativeInst_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/nativeInst_riscv32.cpp
@@ -61,12 +61,8 @@ bool NativeInstruction::is_load_pc_relative_at(address instr) {
 }
 
 bool NativeInstruction::is_movptr_at(address instr) {
-  if (is_lui_at(instr) && // Lui
+  if (is_auipc_at(instr) && // Lui
       is_addi_at(instr + 4) && // Addi
-      is_slli_shift_at(instr + 8, 11) && // Slli Rd, Rs, 11
-      is_addi_at(instr + 12) && // Addi
-      is_slli_shift_at(instr + 16, 5) && // Slli Rd, Rs, 5
-      (is_addi_at(instr + 20) || is_jalr_at(instr + 20) || is_load_at(instr + 20)) && // Addi/Jalr/Load
       check_movptr_data_dependency(instr)) {
     return true;
   }
@@ -328,8 +324,8 @@ void NativeGeneralJump::insert_unconditional(address code_pos, address entry) {
   MacroAssembler a(&cb);
 
   int32_t offset = 0;
-  a.movptr_with_offset(t0, entry, offset); // lui, addi, slli, addi, slli
-  a.jalr(x0, t0, offset); // jalr
+  a.auipc(t0, (int32_t)entry);
+  a.jalr(x0, t0, ((int32_t)entry << 20) >> 20); // jalr
 
   ICache::invalidate_range(code_pos, instruction_size);
 }

--- a/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
@@ -194,13 +194,13 @@ bool SharedRuntime::is_wide_vector(int size) {
 }
 
 size_t SharedRuntime::trampoline_size() {
-  return 2 * NativeInstruction::instruction_size; // auipc + addi
+  return 2 * NativeInstruction::instruction_size; // auipc + jalr
 }
 
 void SharedRuntime::generate_trampoline(MacroAssembler *masm, address destination) {
   assert_cond(masm != NULL);
   __ auipc(t0, (int32_t)destination);
-  __ jalr(x0, t0, ((int32_t)destination<<20)>>20);
+  __ jalr(x0, t0, ((int32_t)destination << 20) >> 20);
 }
 
 // The java_calling_convention describes stack locations as ideal slots on

--- a/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
@@ -194,15 +194,13 @@ bool SharedRuntime::is_wide_vector(int size) {
 }
 
 size_t SharedRuntime::trampoline_size() {
-  // Byte size of function generate_trampoline. movptr_with_offset: 5 instructions, jalr: 1 instrction
-  return 6 * NativeInstruction::instruction_size; // lui + addi + slli + addi + slli + jalr
+  return 2 * NativeInstruction::instruction_size; // auipc + addi
 }
 
 void SharedRuntime::generate_trampoline(MacroAssembler *masm, address destination) {
   assert_cond(masm != NULL);
-  int32_t offset = 0;
-  __ movptr_with_offset(t0, destination, offset); // lui + addi + slli + addi + slli
-  __ jalr(x0, t0, offset);
+  __ auipc(t0, (int32_t)destination);
+  __ jalr(x0, t0, ((int32_t)destination<<20)>>20);
 }
 
 // The java_calling_convention describes stack locations as ideal slots on

--- a/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
@@ -580,8 +580,8 @@ class StubGenerator: public StubCodeGenerator {
 #endif
     BLOCK_COMMENT("call MacroAssembler::debug");
     int32_t offset = 0;
-    __ movptr_with_offset(t0, CAST_FROM_FN_PTR(address, MacroAssembler::debug32), offset);
-    __ jalr(x1, t0, offset);
+    __ auipc(t0, (int32_t)CAST_FROM_FN_PTR(address, MacroAssembler::debug32));
+    __ jalr(x1, t0, ((int32_t)CAST_FROM_FN_PTR(address, MacroAssembler::debug32)<<20)>>20);
 
     return start;
   }
@@ -2744,9 +2744,8 @@ class StubGenerator: public StubCodeGenerator {
     }
     __ mv(c_rarg0, xthread);
     BLOCK_COMMENT("call runtime_entry");
-    int32_t offset = 0;
-    __ movptr_with_offset(t0, runtime_entry, offset);
-    __ jalr(x1, t0, offset);
+    __ auipc(t0, (int32_t)runtime_entry);
+    __ jalr(x1, t0, ((int32_t)runtime_entry<<20)>>20);
 
     // Generate oop map
     OopMap* map = new OopMap(framesize, 0);

--- a/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
@@ -581,7 +581,7 @@ class StubGenerator: public StubCodeGenerator {
     BLOCK_COMMENT("call MacroAssembler::debug");
     int32_t offset = 0;
     __ auipc(t0, (int32_t)CAST_FROM_FN_PTR(address, MacroAssembler::debug32));
-    __ jalr(x1, t0, ((int32_t)CAST_FROM_FN_PTR(address, MacroAssembler::debug32)<<20)>>20);
+    __ jalr(x1, t0, ((int32_t)CAST_FROM_FN_PTR(address, MacroAssembler::debug32) << 20) >> 20);
 
     return start;
   }
@@ -2745,7 +2745,7 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(c_rarg0, xthread);
     BLOCK_COMMENT("call runtime_entry");
     __ auipc(t0, (int32_t)runtime_entry);
-    __ jalr(x1, t0, ((int32_t)runtime_entry<<20)>>20);
+    __ jalr(x1, t0, ((int32_t)runtime_entry << 20) >> 20);
 
     // Generate oop map
     OopMap* map = new OopMap(framesize, 0);

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -414,7 +414,8 @@ void TemplateTable::fast_aldc(bool wide)
 
     // Stash null_sentinel address to get its value later
     int32_t offset = 0;
-    __ movptr_with_offset(rarg, Universe::the_null_sentinel_addr(), offset);
+    __ auipc(rarg, (int32_t)Universe::the_null_sentinel_addr());
+    offset = ((int32_t)Universe::the_null_sentinel_addr() << 20) >> 20;
     __ lw(tmp, Address(rarg, offset));
     __ bne(result, tmp, notNull);
     __ mv(result, zr);  // NULL object reference


### PR DESCRIPTION
The movptr_with_offset is unnecessary in 32bit, it is created to find addr which more than 4G.
Use the auipc to instead of the movptr_with_offset.
Just keep the movptr.