### PR TITLE
Fix compare results about vtableEntry::size() * wordSize in macroAsse…

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -2005,7 +2005,7 @@ void MacroAssembler::lookup_virtual_method(Register recv_klass,
                                            RegisterOrConstant vtable_index,
                                            Register method_result) {
   const int base = in_bytes(Klass::vtable_start_offset());
-  assert(vtableEntry::size() * wordSize == 8,
+  assert(vtableEntry::size() * wordSize == 4,
          "adjust the scaling in the code below");
   int vtable_offset_in_bytes = base + vtableEntry::method_offset_in_bytes();
 


### PR DESCRIPTION
…mbler_riscv32.cpp

Since 'wordSize' is the same with sizeof(char*) in globalDefinitions.hpp, the value of 'wordSize' is 8 in rv64 and 4 in rv32. So change 8 to 4.