### PR TITLE
Improve the auipc in assembler

### DIFF
--- a/src/hotspot/cpu/riscv32/assembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.cpp
@@ -598,7 +598,7 @@ void Assembler::li(Register Rd, int32_t imm) {
       jal(REGISTER, distance);                                     \
     } else {                                                       \
       assert(temp != noreg, "temp must not be empty register!");   \
-      auipc(temp, (int32_t)dest);                                  \
+      auipc(temp, (int32_t)dest + 0x800);                                  \
       jalr(REGISTER, temp, ((int32_t)dest << 20) >> 20);           \
     }                                                              \
   }                                                                \
@@ -632,7 +632,7 @@ void Assembler::ret() {
     int32_t distance = dest - pc();                               \
     if (is_offset_in_range(distance, 32)) {                       \
       auipc(temp, distance + 0x800);                              \
-      jalr(REGISTER, temp, ((int32_t)distance << 20) >> 20);      \
+      jalr(REGISTER, temp, (distance << 20) >> 20);               \
     }                                                             \
   }
 
@@ -708,7 +708,7 @@ void Assembler::movptr(Register Rd, uintptr_t imm32) {
 
 void Assembler::movptr(Register Rd, address addr) {
   int offset = 0;
-  auipc(Rd, (int32_t)addr);
+  auipc(Rd, (int32_t)addr + 0x800);
   addi(Rd, Rd, ((int32_t)addr << 20) >> 20);
 }
 


### PR DESCRIPTION
The auipc need to add 0x800 to make sure the low 12bit in the next instruction will load right, if not
the low 12 bit maybe used from unsigned to signed.