### PR TITLE
Fix auipc instruction added after removing movptr_with_offset

### DIFF
--- a/src/hotspot/cpu/riscv32/assembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.cpp
@@ -598,7 +598,7 @@ void Assembler::li(Register Rd, int32_t imm) {
       jal(REGISTER, distance);                                     \
     } else {                                                       \
       assert(temp != noreg, "temp must not be empty register!");   \
-      auipc(temp, (int32_t)dest + 0x800);                                  \
+      lui(temp, (int32_t)dest + 0x800);                            \
       jalr(REGISTER, temp, ((int32_t)dest << 20) >> 20);           \
     }                                                              \
   }                                                                \
@@ -708,7 +708,7 @@ void Assembler::movptr(Register Rd, uintptr_t imm32) {
 
 void Assembler::movptr(Register Rd, address addr) {
   int offset = 0;
-  auipc(Rd, (int32_t)addr + 0x800);
+  lui(Rd, (int32_t)addr + 0x800);
   addi(Rd, Rd, ((int32_t)addr << 20) >> 20);
 }
 

--- a/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
@@ -486,10 +486,8 @@ public:
   void NAME(FloatRegister Rd, address dest, Register temp = t0) {                                  \
     assert_cond(dest != NULL);                                                                     \
     int32_t distance = (dest - pc());                                                              \
-    if (is_offset_in_range(distance, 32)) {                                                        \
-      auipc(temp, (int32_t)distance);                                                              \
-      NAME(Rd, temp, ((int32_t)distance << 20) >> 20);                                             \
-    }                                                                                              \
+    auipc(temp, distance + 0x800);                                                                 \
+    NAME(Rd, temp, ((int32_t)distance << 20) >> 20);                                               \
   }                                                                                                \
   INSN_ENTRY_RELOC(void, NAME(FloatRegister Rd, address dest, relocInfo::relocType rtype, Register temp = t0)) \
     NAME(Rd, dest, temp);                                                                          \
@@ -604,10 +602,8 @@ public:
     assert_cond(dest != NULL);                                                                     \
     assert_different_registers(Rs, temp);                                                          \
     int32_t distance = (dest - pc());                                                              \
-    if (is_offset_in_range(distance, 32)) {                                                        \
-      auipc(temp, (int32_t)distance);                                                              \
-      NAME(Rs, temp, ((int32_t)distance << 20) >> 20);                                             \
-    }                                                                                              \
+    auipc(temp, distance + 0x800);                                                                 \
+    NAME(Rs, temp, (distance << 20) >> 20);                                                        \
   }                                                                                                \
   void NAME(Register Rs, const Address &adr, Register temp = t0) {                                 \
     switch(adr.getMode()) {                                                                        \
@@ -642,11 +638,9 @@ public:
 #define INSN(NAME)                                                                                 \
   void NAME(FloatRegister Rs, address dest, Register temp = t0) {                                  \
     assert_cond(dest != NULL);                                                                     \
-    int64_t distance = (dest - pc());                                                              \
-    if (is_offset_in_range(distance, 32)) {                                                        \
-      auipc(temp, (int32_t)distance);                                                              \
-      NAME(Rs, temp, ((int32_t)distance << 20) >> 20);                                             \
-    }                                                                                              \
+    int32_t distance = (dest - pc());                                                              \
+    auipc(temp, (int32_t)distance + 0x800);                                                        \
+    NAME(Rs, temp, ((int32_t)distance << 20) >> 20);                                               \
   }                                                                                                \
   void NAME(FloatRegister Rs, const Address &adr, Register temp = t0) {                            \
     switch(adr.getMode()) {                                                                        \
@@ -733,7 +727,7 @@ public:
     } else {                                                                                  \
       assert_different_registers(Rd, temp);                                                   \
       int32_t off = 0;                                                                        \
-      auipc(temp, (int32_t)dest);                                                             \
+      lui(temp, (int32_t)dest + 0x800);                                                       \
       jalr(Rd, temp, ((int32_t)dest<<20)>>20);                                                \
     }                                                                                         \
   }                                                                                           \

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -560,7 +560,7 @@ void MacroAssembler::emit_static_call_stub() {
   mov_metadata(xmethod, (Metadata*)NULL);
 
   // Jump to the entry point of the i2c stub.
-  auipc(t0, 0);
+  lui(t0, 0);
   jalr(x0, t0, 0);
 }
 void MacroAssembler::call_VM_leaf_base(address entry_point,
@@ -579,7 +579,7 @@ void MacroAssembler::call_native_base(address entry_point, Label *retaddr) {
   Label E, L;
   int32_t offset = 0;
   push_reg(0x80000040, sp);   // push << t0 & xmethod >> to sp
-  auipc(t0, (int32_t)entry_point);
+  lui(t0, (int32_t)entry_point + 0x800);
   jalr(x1, t0, ((int32_t)entry_point<<20)>>20);
   if (retaddr != NULL) {
     bind(*retaddr);
@@ -2909,7 +2909,7 @@ void MacroAssembler::la_patchable(Register reg1, const Address &dest, int32_t &o
   code_section()->relocate(inst_mark(), dest.rspec());
 
   int32_t distance = dest.target() - pc();
-  auipc(reg1, (int32_t)distance);
+  auipc(reg1, (int32_t)distance + 0x800);
   offset = ((int32_t)distance << 20) >> 20;
 }
 

--- a/src/hotspot/cpu/riscv32/nativeInst_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/nativeInst_riscv32.cpp
@@ -61,7 +61,7 @@ bool NativeInstruction::is_load_pc_relative_at(address instr) {
 }
 
 bool NativeInstruction::is_movptr_at(address instr) {
-  if (is_auipc_at(instr) && // Lui
+  if (is_lui_at(instr) && // lui
       is_addi_at(instr + 4) && // Addi
       check_movptr_data_dependency(instr)) {
     return true;
@@ -324,7 +324,7 @@ void NativeGeneralJump::insert_unconditional(address code_pos, address entry) {
   MacroAssembler a(&cb);
 
   int32_t offset = 0;
-  a.auipc(t0, (int32_t)entry);
+  a.lui(t0, (int32_t)entry + 0x800);
   a.jalr(x0, t0, ((int32_t)entry << 20) >> 20); // jalr
 
   ICache::invalidate_range(code_pos, instruction_size);

--- a/src/hotspot/cpu/riscv32/nativeInst_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/nativeInst_riscv32.hpp
@@ -93,10 +93,10 @@ class NativeInstruction {
   }
 
   // the instruction sequence of movptr is as below:
-  //     auipc
+  //     luipc
   //     addi
   static bool check_movptr_data_dependency(address instr) {
-    return compare_instr_field(instr, 11, 7, instr + 4, 19, 15);          // check the rd field of auipc and the rs1 field of addi
+    return compare_instr_field(instr, 11, 7, instr + 4, 19, 15);          // check the rd field of lui and the rs1 field of addi
   }
 
   // the instruction sequence of li is as below:
@@ -277,7 +277,7 @@ inline NativeCall* nativeCall_before(address return_address) {
 class NativeMovConstReg: public NativeInstruction {
  public:
   enum RISCV32_specific_constants {
-    movptr_instruction_size             =    2 * NativeInstruction::instruction_size, // auipc, addi
+    movptr_instruction_size             =    2 * NativeInstruction::instruction_size, // lui, addi
     load_pc_relative_instruction_size   =    2 * NativeInstruction::instruction_size, // auipc, ld
     instruction_offset                  =    0,
     displacement_offset                 =    0

--- a/src/hotspot/cpu/riscv32/nativeInst_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/nativeInst_riscv32.hpp
@@ -93,7 +93,7 @@ class NativeInstruction {
   }
 
   // the instruction sequence of movptr is as below:
-  //     luipc
+  //     lui
   //     addi
   static bool check_movptr_data_dependency(address instr) {
     return compare_instr_field(instr, 11, 7, instr + 4, 19, 15);          // check the rd field of lui and the rs1 field of addi

--- a/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
@@ -194,12 +194,12 @@ bool SharedRuntime::is_wide_vector(int size) {
 }
 
 size_t SharedRuntime::trampoline_size() {
-  return 2 * NativeInstruction::instruction_size; // auipc + jalr
+  return 2 * NativeInstruction::instruction_size; // lui + jalr
 }
 
 void SharedRuntime::generate_trampoline(MacroAssembler *masm, address destination) {
   assert_cond(masm != NULL);
-  __ auipc(t0, (int32_t)destination);
+  __ lui(t0, (int32_t)destination + 0x800);
   __ jalr(x0, t0, ((int32_t)destination << 20) >> 20);
 }
 

--- a/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
@@ -580,7 +580,7 @@ class StubGenerator: public StubCodeGenerator {
 #endif
     BLOCK_COMMENT("call MacroAssembler::debug");
     int32_t offset = 0;
-    __ auipc(t0, (int32_t)CAST_FROM_FN_PTR(address, MacroAssembler::debug32));
+    __ lui(t0, (int32_t)CAST_FROM_FN_PTR(address, MacroAssembler::debug32) + 0x800);
     __ jalr(x1, t0, ((int32_t)CAST_FROM_FN_PTR(address, MacroAssembler::debug32) << 20) >> 20);
 
     return start;
@@ -2740,7 +2740,7 @@ class StubGenerator: public StubCodeGenerator {
     }
     __ mv(c_rarg0, xthread);
     BLOCK_COMMENT("call runtime_entry");
-    __ auipc(t0, (int32_t)runtime_entry);
+    __ lui(t0, (int32_t)runtime_entry + 0x800);
     __ jalr(x1, t0, ((int32_t)runtime_entry << 20) >> 20);
 
     // Generate oop map

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -414,7 +414,7 @@ void TemplateTable::fast_aldc(bool wide)
 
     // Stash null_sentinel address to get its value later
     int32_t offset = 0;
-    __ auipc(rarg, (int32_t)Universe::the_null_sentinel_addr());
+    __ lui(rarg, (int32_t)Universe::the_null_sentinel_addr() + 0x800);
     offset = ((int32_t)Universe::the_null_sentinel_addr() << 20) >> 20;
     __ lw(tmp, Address(rarg, offset));
     __ bne(result, tmp, notNull);


### PR DESCRIPTION
Change some auipc to lui with parameter of absolute address and add 0x800 to make sure the low 12bit in the next instruction will load right.
Change some comment text of 'auipc' to 'lui'.
Remove uesless 'if' of distance judgement and typecast of int32_t.