### PR TITLE
Remove the condition in lload

### DIFF
--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -896,11 +896,8 @@ void TemplateTable::iload(int n)
 
 void TemplateTable::lload(int n)
 {
-  if (n <= 3)
-  {
-    transition(vtos, ltos);
-    __ lw(x10, laddress(n));
-  }
+  transition(vtos, ltos);
+  __ lw(x10, laddress(n));
 }
 
 void TemplateTable::fload(int n)


### PR DESCRIPTION
Base the new code, the lload function don't need the condition to protect it. So remove the condition.