### PR TITLE
Update the registerSize

### DIFF
--- a/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
@@ -31,7 +31,7 @@
 #include "asm/register.hpp"
 #include "assembler_riscv32.inline.hpp"
 
-#define registerSize 64
+#define registerSize 32
 
 // definitions of various symbolic names for machine registers
 


### PR DESCRIPTION
The registerSize of rv32g must be 32, not be 64. So, update the value of registerSize to 32.