### PR TITLE
Remove RV64A and fix RV32A instructions

### DIFF
--- a/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
@@ -818,15 +818,6 @@ enum Aqrl {relaxed = 0b00, rl = 0b01, aq = 0b10, aqrl = 0b11};
   INSN(amomax_w,  0b0101111, 0b010, 0b10100);
   INSN(amominu_w, 0b0101111, 0b010, 0b11000);
   INSN(amomaxu_w, 0b0101111, 0b010, 0b11100);
-  INSN(amoswap_d, 0b0101111, 0b011, 0b00001);
-  INSN(amoadd_d,  0b0101111, 0b011, 0b00000);
-  INSN(amoxor_d,  0b0101111, 0b011, 0b00100);
-  INSN(amoand_d,  0b0101111, 0b011, 0b01100);
-  INSN(amoor_d,   0b0101111, 0b011, 0b01000);
-  INSN(amomin_d,  0b0101111, 0b011, 0b10000);
-  INSN(amomax_d , 0b0101111, 0b011, 0b10100);
-  INSN(amominu_d, 0b0101111, 0b011, 0b11000);
-  INSN(amomaxu_d, 0b0101111, 0b011, 0b11100);
 #undef INSN
 
 enum operand_size { int8, int16, int32, uint32, int64 };

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -2371,10 +2371,8 @@ void MacroAssembler::atomic_##NAME(Register prev, RegisterOrConstant incr, Regis
   return;                                                                                   \
 }
 
-ATOMIC_OP(add, amoadd_d, Assembler::relaxed, Assembler::relaxed)
-ATOMIC_OP(addw, amoadd_w, Assembler::relaxed, Assembler::relaxed)
-ATOMIC_OP(addal, amoadd_d, Assembler::aq, Assembler::rl)
-ATOMIC_OP(addalw, amoadd_w, Assembler::aq, Assembler::rl)
+ATOMIC_OP(add, amoadd_w, Assembler::relaxed, Assembler::relaxed)
+ATOMIC_OP(addal, amoadd_w, Assembler::aq, Assembler::rl)
 
 #undef ATOMIC_OP
 
@@ -2385,10 +2383,8 @@ void MacroAssembler::atomic_##OP(Register prev, Register newv, Register addr) { 
   return;                                                                            \
 }
 
-ATOMIC_XCHG(xchg, amoswap_d, Assembler::relaxed, Assembler::relaxed)
-ATOMIC_XCHG(xchgw, amoswap_w, Assembler::relaxed, Assembler::relaxed)
-ATOMIC_XCHG(xchgal, amoswap_d, Assembler::aq, Assembler::rl)
-ATOMIC_XCHG(xchgalw, amoswap_w, Assembler::aq, Assembler::rl)
+ATOMIC_XCHG(xchg, amoswap_w, Assembler::relaxed, Assembler::relaxed)
+ATOMIC_XCHG(xchgal, amoswap_w, Assembler::aq, Assembler::rl)
 
 #undef ATOMIC_XCHG
 
@@ -2399,8 +2395,8 @@ void MacroAssembler::atomic_##OP1(Register prev, Register newv, Register addr) {
   return;                                                                            \
 }
 
-ATOMIC_XCHGU(xchgwu, xchgw)
-ATOMIC_XCHGU(xchgalwu, xchgalw)
+ATOMIC_XCHGU(xchgu, xchg)
+ATOMIC_XCHGU(xchgalu, xchgal)
 
 #undef ATOMIC_XCHGU
 

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -556,11 +556,9 @@ class MacroAssembler: public Assembler {
   void atomic_addalw(Register prev, RegisterOrConstant incr, Register addr);
 
   void atomic_xchg(Register prev, Register newv, Register addr);
-  void atomic_xchgw(Register prev, Register newv, Register addr);
   void atomic_xchgal(Register prev, Register newv, Register addr);
-  void atomic_xchgalw(Register prev, Register newv, Register addr);
-  void atomic_xchgwu(Register prev, Register newv, Register addr);
-  void atomic_xchgalwu(Register prev, Register newv, Register addr);
+  void atomic_xchgu(Register prev, Register newv, Register addr);
+  void atomic_xchgalu(Register prev, Register newv, Register addr);
 
   // Biased locking support
   // lock_reg and obj_reg must be loaded up with the appropriate values.

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -5641,10 +5641,10 @@ instruct get_and_setN(indirect mem, iRegN newv, iRegINoSp prev)
 
   ins_cost(ALU_COST);
 
-  format %{ "atomic_xchgwu $prev, $newv, [$mem]\t#@get_and_setN" %}
+  format %{ "atomic_xchgu $prev, $newv, [$mem]\t#@get_and_setN" %}
 
   ins_encode %{
-    __ atomic_xchgwu($prev$$Register, $newv$$Register, as_Register($mem$$base));
+    __ atomic_xchgu($prev$$Register, $newv$$Register, as_Register($mem$$base));
   %}
 
   ins_pipe(pipe_serial);
@@ -5707,10 +5707,10 @@ instruct get_and_setNAcq(indirect mem, iRegN newv, iRegINoSp prev)
 
   ins_cost(ALU_COST);
 
-  format %{ "atomic_xchgwu_acq $prev, $newv, [$mem]\t#@get_and_setNAcq" %}
+  format %{ "atomic_xchgu_acq $prev, $newv, [$mem]\t#@get_and_setNAcq" %}
 
   ins_encode %{
-    __ atomic_xchgalwu($prev$$Register, $newv$$Register, as_Register($mem$$base));
+    __ atomic_xchgalu($prev$$Register, $newv$$Register, as_Register($mem$$base));
   %}
 
   ins_pipe(pipe_serial);

--- a/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
@@ -1871,7 +1871,7 @@ void TemplateInterpreterGenerator::count_bytecode() {
   __ push_reg(x10);
   __ mv(x10, (address) &BytecodeCounter::_counter_value);
   __ li(t0, 1);
-  __ amoadd_d(zr, x10, t0, Assembler::aqrl);
+  __ amoadd_w(zr, x10, t0, Assembler::aqrl);
   __ pop_reg(x10);
   __ pop_reg(t0);
 }


### PR DESCRIPTION
Remove amoswap_d, amoadd_d, amoxor_d, amoand_d, amoor_d, amomin_d, amomax_d , amominu_d, amomaxu_d in src/hotspot/cpu/riscv32/assembler_riscv32.hpp.
Remove addw, addalw, xchgw, xchgalw and fix xchg, xchgal, xchgu, xchgalu in src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp.
Remove atomic_xchgw, atomic_xchgalw, atomic_xchgwu, atomic_xchgalwu and add atomic_xchgu, atomic_xchgalu in src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp.
Change text of atomic_xchgwu to atomic_xchgu and change text of atomic_xchglwu to atomic_xchglu in src/hotspot/cpu/riscv32/riscv32.ad.
Change amoadd_d to amoadd_w in src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp.