### PR TITLE
Fix patch_addr_in_movptr

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1171,13 +1171,11 @@ static int patch_offset_in_pc_relative(address branch, int32_t offset) {
 }
 
 static int patch_addr_in_movptr(address branch, address target) {
-  const int MOVPTR_INSTRUCTIONS_NUM = 6;                                                  // lui + addi + slli + addi + slli + addi/jalr/load
+  const int MOVPTR_INSTRUCTIONS_NUM = 2;                                                  // lui + addi
   int32_t lower = ((intptr_t)target << 20) >> 20;
   int32_t upper = ((intptr_t)target - lower);
   Assembler::patch(branch + 0,  31, 12, upper & 0xfffff);                       // Lui.             target[47:28] + target[27] ==> branch[31:12]
   Assembler::patch(branch + 4,  31, 20, (lower >> 16) & 0xfff);                 // Addi.            target[27:16] ==> branch[31:20]
-  Assembler::patch(branch + 12, 31, 20, (lower >> 5) & 0x7ff);                  // Addi.            target[15: 5] ==> branch[31:20]
-  Assembler::patch(branch + 20, 31, 20, lower & 0x1f);                          // Addi/Jalr/Load.  target[ 4: 0] ==> branch[31:20]
   return MOVPTR_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
 }
 


### PR DESCRIPTION
Since the instructions sequence of 'movptr' changed from 'lui + addi + slli + addi + slli + addi/jalr/load' to 'lui + addi', function 'patch_addr_in_movptr' should be fixed.