### PR TITLE
Fix bit operation in patch_addr_in_movptr

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1174,8 +1174,8 @@ static int patch_addr_in_movptr(address branch, address target) {
   const int MOVPTR_INSTRUCTIONS_NUM = 2;                                                  // lui + addi
   int32_t lower = ((intptr_t)target << 20) >> 20;
   int32_t upper = ((intptr_t)target - lower);
-  Assembler::patch(branch + 0,  31, 12, upper & 0xfffff);                       // Lui.             target[47:28] + target[27] ==> branch[31:12]
-  Assembler::patch(branch + 4,  31, 20, (lower >> 16) & 0xfff);                 // Addi.            target[27:16] ==> branch[31:20]
+  Assembler::patch(branch + 0,  31, 12, upper);                       // Lui.             target[31:12] ==> branch[31:12]
+  Assembler::patch(branch + 4,  31, 20, lower);                       // Addi.            target[11: 0] ==> branch[31:20]
   return MOVPTR_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
 }
 


### PR DESCRIPTION
Since bit operation in patch_addr_in_movptr is still work with 64bit, fix it.