### PR TITLE
Fix the slli instruction in the dispatch_base function using incorrect operands

### DIFF
--- a/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
@@ -520,11 +520,11 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
   if (table == Interpreter::dispatch_table(state)) {
     li(t1, Interpreter::distance_from_dispatch_table(state));
     add(t1, Rs, t1);
-    slli(t1, t1, 3);
+    slli(t1, t1, 2);
     add(t1, xdispatch, t1);
   } else {
     mv(t1, (address)table);
-    slli(Rs, Rs, 3);
+    slli(Rs, Rs, 2);
     add(t1, t1, Rs);
   }
   lw(t1, Address(t1));
@@ -533,7 +533,7 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
   if (needs_thread_local_poll) {
     bind(safepoint);
     la(t1, ExternalAddress((address)safepoint_table));
-    slli(Rs, Rs, 3);
+    slli(Rs, Rs, 2);
     add(t1, t1, Rs);
     lw(t1, Address(t1));
     jr(t1);


### PR DESCRIPTION
Fixed the bug in using the operand of the slli instruction in the InterpreterMacroAssembler::dispatch_base function. On a 32-bit cpu, only need to shift 2 bits to the left. For details, please refer to: https://github.com/openjdk-riscv/jdk11u/issues/184