### PR TITLE
fix grevh for riscv32

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1439,8 +1439,8 @@ void MacroAssembler::grevh(Register Rd, Register Rs, Register Rtmp) {
   assert_different_registers(Rd, Rtmp);
   srli(Rtmp, Rs, 8);
   andi(Rtmp, Rtmp, 0xFF);
-  slli(Rd, Rs, 56);
-  srai(Rd, Rd, 48); // sign-extend
+  slli(Rd, Rs, 24);
+  srai(Rd, Rd, 16); // sign-extend
   orr(Rd, Rd, Rtmp);
 }
 


### PR DESCRIPTION
Since the length of register is 32 in rv32,fix the offset from 56 to 24 ,and fix the offset from 48 to 16.