### PR TITLE
Fix lr_w and sc_w in macroAssembler_riscv32.cpp

### DIFF
--- a/src/hotspot/cpu/riscv32/gc/shared/barrierSetAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/gc/shared/barrierSetAssembler_riscv32.cpp
@@ -187,7 +187,7 @@ void BarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register obj,
     ExternalAddress address_top((address) Universe::heap()->top_addr());
     __ la_patchable(t2, address_top, offset);
     __ addi(t2, t2, offset);
-    __ lr_d(obj, t2, Assembler::aqrl);
+    __ lr_w(obj, t2, Assembler::aqrl);
 
     // Adjust it my the size of our new object
     if (var_size_in_bytes == noreg) {
@@ -209,7 +209,7 @@ void BarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register obj,
     __ bgtu(end, heap_end, slow_case, is_far);
 
     // If heap_top hasn't been changed by some other thread, update it.
-    __ sc_d(t1, end, t2, Assembler::rl);
+    __ sc_w(t1, end, t2, Assembler::rl);
     __ bnez(t1, retry);
     incr_allocated_bytes(masm, var_size_in_bytes, con_size_in_bytes, tmp1);
   }

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -2100,10 +2100,10 @@ void MacroAssembler::cmpxchgptr(Register oldv, Register newv, Register addr, Reg
   bind(retry_load);
   // flush and load exclusive from the memory location
   // and fail if it is not what we expect
-  lr_d(tmp, addr, Assembler::aqrl);
+  lr_w(tmp, addr, Assembler::aqrl);
   bne(tmp, oldv, nope);
   // if we store+flush with no intervening write tmp wil be zero
-  sc_d(tmp, newv, addr, Assembler::rl);
+  sc_w(tmp, newv, addr, Assembler::rl);
   beqz(tmp, succeed);
   // retry so we only ever return after a load fails to compare
   // ensures we don't return a stale value after a failed write.


### PR DESCRIPTION
Change lr_d/sc_d to lr_w/sc_w in macroAssembler_riscv32.cpp and barrierSetAssembler_riscv32.cpp for riscv32.