### PR TITLE
Fix slli of iaddress in templateTable_riscv32.cpp

### DIFF
--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -80,7 +80,7 @@ static inline Address aaddress(int n) {
 
 static inline Address iaddress(Register r,  Register temp, InterpreterMacroAssembler* _masm) {
   assert_cond(_masm != NULL);
-  _masm->slli(temp, r, 3);
+  _masm->slli(temp, r, 2);
   _masm->add(temp, xlocals, temp);
   return Address(temp, 0);
 }


### PR DESCRIPTION
Fix the 'slli' offset of iaddress in templateTable_riscv32.cpp from 3 to 2.