### PR TITLE
Clean the sllw/slliw/sraw/sraiw/srlw/srliw

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -3321,10 +3321,10 @@ void MacroAssembler::string_compare(Register str1, Register str2,
   // Bizzarely, the counts are passed in bytes, regardless of whether they
   // are L or U strings, however the result is always in characters.
   if (!str1_isL) {
-    sraiw(cnt1, cnt1, 1);
+    srai(cnt1, cnt1, 1);
   }
   if (!str2_isL) {
-    sraiw(cnt2, cnt2, 1);
+    srai(cnt2, cnt2, 1);
   }
 
   // Compute the minimum of the string lengths and save the difference in result.

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -6305,10 +6305,10 @@ instruct divI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
 instruct signExtract(iRegINoSp dst, iRegIorL2I src1, immI_31 div1, immI_31 div2) %{
   match(Set dst (URShiftI (RShiftI src1 div1) div2));
   ins_cost(ALU_COST);
-  format %{ "srliw $dst, $src1, $div1\t# int signExtract, #@signExtract" %}
+  format %{ "srli $dst, $src1, $div1\t# int signExtract, #@signExtract" %}
 
   ins_encode %{
-    __ srliw(as_Register($dst$$reg), as_Register($src1$$reg), 31);
+    __ srli(as_Register($dst$$reg), as_Register($src1$$reg), 31);
   %}
   ins_pipe(ialu_reg_shift);
 %}
@@ -6363,10 +6363,10 @@ instruct modL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 instruct lShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (LShiftI src1 src2));
   ins_cost(ALU_COST);
-  format %{ "sllw  $dst, $src1, $src2\t#@lShiftI_reg_reg" %}
+  format %{ "sll  $dst, $src1, $src2\t#@lShiftI_reg_reg" %}
 
   ins_encode %{
-    __ sllw(as_Register($dst$$reg),
+    __ sll(as_Register($dst$$reg),
             as_Register($src1$$reg),
             as_Register($src2$$reg));
   %}
@@ -6378,12 +6378,12 @@ instruct lShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
 instruct lShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
   match(Set dst (LShiftI src1 src2));
   ins_cost(ALU_COST);
-  format %{ "slliw  $dst, $src1, ($src2 & 0x1f)\t#@lShiftI_reg_imm" %}
+  format %{ "slli  $dst, $src1, ($src2 & 0x1f)\t#@lShiftI_reg_imm" %}
 
   ins_encode %{
     // the shift amount is encoded in the lower
     // 5 bits of the I-immediate field for RV32I
-    __ slliw(as_Register($dst$$reg),
+    __ slli(as_Register($dst$$reg),
              as_Register($src1$$reg),
              (unsigned) $src2$$constant & 0x1f);
   %}
@@ -6395,10 +6395,10 @@ instruct lShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 instruct urShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (URShiftI src1 src2));
   ins_cost(ALU_COST);
-  format %{ "srlw  $dst, $src1, $src2\t#@urShiftI_reg_reg" %}
+  format %{ "srl  $dst, $src1, $src2\t#@urShiftI_reg_reg" %}
 
   ins_encode %{
-    __ srlw(as_Register($dst$$reg),
+    __ srl(as_Register($dst$$reg),
             as_Register($src1$$reg),
             as_Register($src2$$reg));
   %}
@@ -6410,12 +6410,12 @@ instruct urShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
 instruct urShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
   match(Set dst (URShiftI src1 src2));
   ins_cost(ALU_COST);
-  format %{ "srliw  $dst, $src1, ($src2 & 0x1f)\t#@urShiftI_reg_imm" %}
+  format %{ "srli  $dst, $src1, ($src2 & 0x1f)\t#@urShiftI_reg_imm" %}
 
   ins_encode %{
     // the shift amount is encoded in the lower
     // 6 bits of the I-immediate field for RV32I
-    __ srliw(as_Register($dst$$reg),
+    __ srli(as_Register($dst$$reg),
              as_Register($src1$$reg),
              (unsigned) $src2$$constant & 0x1f);
   %}
@@ -6427,11 +6427,10 @@ instruct urShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 instruct rShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (RShiftI src1 src2));
   ins_cost(ALU_COST);
-  format %{ "sraw  $dst, $src1, $src2\t#@rShiftI_reg_reg" %}
+  format %{ "sra  $dst, $src1, $src2\t#@rShiftI_reg_reg" %}
 
   ins_encode %{
-    // riscv will sign-ext dst high 32 bits
-    __ sraw(as_Register($dst$$reg),
+    __ sra(as_Register($dst$$reg),
             as_Register($src1$$reg),
             as_Register($src2$$reg));
   %}
@@ -6443,11 +6442,10 @@ instruct rShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
 instruct rShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
   match(Set dst (RShiftI src1 src2));
   ins_cost(ALU_COST);
-  format %{ "sraiw  $dst, $src1, ($src2 & 0x1f)\t#@rShiftI_reg_imm" %}
+  format %{ "srai  $dst, $src1, ($src2 & 0x1f)\t#@rShiftI_reg_imm" %}
 
   ins_encode %{
-    // riscv will sign-ext dst high 32 bits
-    __ sraiw(as_Register($dst$$reg),
+    __ srai(as_Register($dst$$reg),
              as_Register($src1$$reg),
              (unsigned) $src2$$constant & 0x1f);
   %}
@@ -8032,10 +8030,10 @@ instruct cmpLTMask_reg_zero(iRegINoSp dst, iRegIorL2I op, immI0 zero)
 
   ins_cost(ALU_COST);
 
-  format %{ "sraiw $dst, $dst, 31\t#@cmpLTMask_reg_reg" %}
+  format %{ "srai $dst, $dst, 31\t#@cmpLTMask_reg_reg" %}
 
   ins_encode %{
-    __ sraiw(as_Register($dst$$reg), as_Register($op$$reg), 31);
+    __ srai(as_Register($dst$$reg), as_Register($op$$reg), 31);
   %}
 
   ins_pipe(ialu_reg_shift);


### PR DESCRIPTION
Use the sll to instead the sllw,
use the slli to insted the slliw,
use the sra to insated the sraw,
use the srai to instead the sraiw,
use the srl to instead the srlw,
use the srli to instead the srliw.

After this patch, the RV32 code will be cleaned in
the sllw/slliw/sraw/sraiw/srlw/srliw.