### PR TITLE
fix slli on generate_native_entry

### DIFF
--- a/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
@@ -1003,7 +1003,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // for natives the size of locals is zero
 
   // compute beginning of parameters (xlocals)
-  __ slli(xlocals, x12, 3);
+  __ slli(xlocals, x12, 2);
   __ add(xlocals, esp, xlocals);
   __ addi(xlocals, xlocals, -wordSize);
 


### PR DESCRIPTION
Since the length of pointer is 4,fix the offset of slli from 3 to 2 on generate_native_entry.