### PR TITLE
Fix fcvt_xx in templateTable_riscv32.cpp

### DIFF
--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -1680,16 +1680,16 @@ void TemplateTable::convert()
     __ add(x10, x10, zr);
     break;
   case Bytecodes::_l2f:
-    __ fcvt_s_l(f10, x10);
+    __ fcvt_s_w(f10, x10);
     break;
   case Bytecodes::_l2d:
-    __ fcvt_d_l(f10, x10);
+    __ fcvt_d_w(f10, x10);
     break;
   case Bytecodes::_f2i:
     __ fcvt_w_s_safe(x10, f10);
     break;
   case Bytecodes::_f2l:
-    __ fcvt_l_s_safe(x10, f10);
+    __ fcvt_w_s_safe(x10, f10);
     break;
   case Bytecodes::_f2d:
     __ fcvt_d_s(f10, f10);
@@ -1698,7 +1698,7 @@ void TemplateTable::convert()
     __ fcvt_w_d_safe(x10, f10);
     break;
   case Bytecodes::_d2l:
-    __ fcvt_l_d_safe(x10, f10);
+    __ fcvt_w_d_safe(x10, f10);
     break;
   case Bytecodes::_d2f:
     __ fcvt_s_d(f10, f10);


### PR DESCRIPTION
Change instructions: fcvt_s_l -> fcvt_s_w, fcvt_d_l -> fcvt_d_w, fcvt_l_s_safe -> fcvt_w_s_safe, fcvt_l_d_safe -> fcvt_w_d_safe in templateTable_riscv32.cpp for riscv32.