### PR TITLE
Remove the andrw/xorw/xorrw

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1336,21 +1336,6 @@ void MacroAssembler::mv(Register Rd, RegisterOrConstant src) {
   }
 }
 
-void MacroAssembler::andrw(Register Rd, Register Rs1, Register Rs2) {
-  andr(Rd, Rs1, Rs2);
-  add(Rd, Rd, zr);
-}
-
-void MacroAssembler::orrw(Register Rd, Register Rs1, Register Rs2) {
-  orr(Rd, Rs1, Rs2);
-  add(Rd, Rd, zr);
-}
-
-void MacroAssembler::xorrw(Register Rd, Register Rs1, Register Rs2) {
-  xorr(Rd, Rs1, Rs2);
-  add(Rd, Rd, zr);
-}
-
 // Note: load_unsigned_short used to be called load_unsigned_word.
 int MacroAssembler::load_unsigned_short(Register dst, Address src) {
   int off = offset();

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -500,11 +500,6 @@ class MacroAssembler: public Assembler {
   void mv(Register Rd, address addr);
   void mv(Register Rd, RegisterOrConstant src);
 
-  // logic
-  void andrw(Register Rd, Register Rs1, Register Rs2);
-  void orrw(Register Rd, Register Rs1, Register Rs2);
-  void xorrw(Register Rd, Register Rs1, Register Rs2);
-
   // grev
   void grevh(Register Rd, Register Rs, Register Rtmp = t0);                            // basic reverse bytes in 16-bit halfwords, sign-extend
   void grev16w(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);    // reverse bytes in 16-bit halfwords(32), sign-extend

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -498,7 +498,7 @@ void TemplateTable::condy_helper(Label& Done)
   // VMr2 = flags = (tos, off) using format of CPCE::_flags
   __ mv(off, flags);
   __ mv(t0, ConstantPoolCacheEntry::field_index_mask);
-  __ andrw(off, off, t0);
+  __ andr(off, off, t0);
 
   __ add(off, obj, off);
   const Address field(off, 0); // base + R---->base + offset


### PR DESCRIPTION
The andrw/xorw/xorrw are useless in the RV32G, and they just be used
1 time.
Just remove them, and use the andr instead the andrw, which used.