### PR TITLE
Remove the mvw

### DIFF
--- a/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
@@ -148,7 +148,7 @@ void InterpreterMacroAssembler::load_earlyret_value(TosState state) {
       ShouldNotReachHere();
   }
   // Clean up tos value in the thread object
-  mvw(t0, (int) ilgl);
+  mv(t0, (int) ilgl);
   sw(t0, tos_addr);
   sw(zr, val_addr);
 }
@@ -1480,8 +1480,8 @@ void InterpreterMacroAssembler::profile_switch_case(Register index,
 
     // Build the base (index * per_case_size_in_bytes()) +
     // case_array_offset_in_bytes()
-    mvw(reg2, in_bytes(MultiBranchData::per_case_size()));
-    mvw(t0, in_bytes(MultiBranchData::case_array_offset()));
+    mv(reg2, in_bytes(MultiBranchData::per_case_size()));
+    mv(t0, in_bytes(MultiBranchData::case_array_offset()));
     Assembler::mul(index, index, reg2);
     Assembler::add(index, index, t0);
 

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1312,10 +1312,6 @@ void MacroAssembler::mv(Register Rd, int imm) {
   li(Rd, imm);
 }
 
-void MacroAssembler::mvw(Register Rd, int32_t imm32) {
-  mv(Rd, imm32);
-}
-
 void MacroAssembler::mv(Register Rd, Address dest) {
   assert(dest.getMode() == Address::literal, "Address mode should be Address::literal");
   code_section()->relocate(pc(), dest.rspec());

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -495,7 +495,6 @@ class MacroAssembler: public Assembler {
 
   // mv
   void mv(Register Rd, int imm);
-  void mvw(Register Rd, int32_t imm32);
   void mv(Register Rd, Address dest);
   void mv(Register Rd, address addr);
   void mv(Register Rd, RegisterOrConstant src);

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -3410,9 +3410,8 @@ opclass memory(indirect, indOffI, indOffL, indirectN, indOffIN, indOffLN);
 // n.b. this does not elide all L2I conversions. if the truncated
 // value is consumed by more than one operation then the ConvL2I
 // cannot be bundled into the consuming nodes so an l2i gets planted
-// (actually a mvw $dst $src) and the downstream instructions consume
-// the result of the l2i as an iRegI input. That's a shame since the
-// mvw is actually redundant but its not too costly.
+// (actually a mv $dst $src) and the downstream instructions consume
+// the result of the l2i as an iRegI input.
 
 opclass iRegIorL2I(iRegI, iRegL2I);
 opclass iRegIorL(iRegI, iRegL);

--- a/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
@@ -2146,7 +2146,7 @@ void SharedRuntime::generate_deopt_blob() {
   map = RegisterSaver::save_live_registers(masm, 0, &frame_size_in_words);
 
   // Normal deoptimization.  Save exec mode for unpack_frames.
-  __ mvw(xcpool, Deoptimization::Unpack_deopt); // callee-saved
+  __ mv(xcpool, Deoptimization::Unpack_deopt); // callee-saved
   __ j(cont);
 
   int reexecute_offset = __ pc() - start;
@@ -2157,7 +2157,7 @@ void SharedRuntime::generate_deopt_blob() {
   // No need to update map as each call to save_live_registers will produce identical oopmap
   (void) RegisterSaver::save_live_registers(masm, 0, &frame_size_in_words);
 
-  __ mvw(xcpool, Deoptimization::Unpack_reexecute); // callee-saved
+  __ mv(xcpool, Deoptimization::Unpack_reexecute); // callee-saved
   __ j(cont);
 
   int exception_offset = __ pc() - start;
@@ -2452,7 +2452,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   // n.b. 3 gp args, 0 fp args, integral return type
 
   __ mv(c_rarg0, xthread);
-  __ mvw(c_rarg2, (unsigned)Deoptimization::Unpack_uncommon_trap);
+  __ mv(c_rarg2, (unsigned)Deoptimization::Unpack_uncommon_trap);
   int32_t offset = 0;
   __ la_patchable(t0,
         RuntimeAddress(CAST_FROM_FN_PTR(address,
@@ -2477,7 +2477,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
 #ifdef ASSERT
   { Label L;
     __ lw(t0, Address(x14, Deoptimization::UnrollBlock::unpack_kind_offset_in_bytes()));
-    __ mvw(t1, Deoptimization::Unpack_uncommon_trap);
+    __ mv(t1, Deoptimization::Unpack_uncommon_trap);
     __ beq(t0, t1, L);
     __ stop("SharedRuntime::generate_deopt_blob: last_Java_fp not cleared");
     __ bind(L);
@@ -2580,7 +2580,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
 
   // sp should already be aligned
   __ mv(c_rarg0, xthread);
-  __ mvw(c_rarg1, (unsigned)Deoptimization::Unpack_uncommon_trap);
+  __ mv(c_rarg1, (unsigned)Deoptimization::Unpack_uncommon_trap);
   offset = 0;
   __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames)), offset);
   __ jalr(x1, t0, offset);

--- a/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
@@ -1663,7 +1663,7 @@ class StubGenerator: public StubCodeGenerator {
     // Handle objArrays completely differently...
     const jint objArray_lh = Klass::array_layout_helper(T_OBJECT);
     __ lw(lh, Address(scratch_src_klass, lh_offset));
-    __ mvw(t0, objArray_lh);
+    __ mv(t0, objArray_lh);
     __ beq(lh, t0, L_objArray);
 
     // if [src->klass() != dst->klass()] then return -1
@@ -1680,7 +1680,7 @@ class StubGenerator: public StubCodeGenerator {
     {
       BLOCK_COMMENT("assert primitive array {");
       Label L;
-      __ mvw(t1, Klass::_lh_array_tag_type_value << Klass::_lh_array_tag_shift);
+      __ mv(t1, Klass::_lh_array_tag_type_value << Klass::_lh_array_tag_shift);
       __ bge(lh, t1, L);
       __ stop("must be a primitive array");
       __ bind(L);
@@ -1757,7 +1757,7 @@ class StubGenerator: public StubCodeGenerator {
       Label L;
       __ andi(lh, lh, Klass::_lh_log2_element_size_mask); // lh -> x22_elsize
       __ add(lh, lh, zr);
-      __ mvw(t0, LogBytesPerLong);
+      __ mv(t0, LogBytesPerLong);
       __ beq(x22_elsize, t0, L);
       __ stop("must be long copy, but elsize is wrong");
       __ bind(L);
@@ -1799,7 +1799,7 @@ class StubGenerator: public StubCodeGenerator {
     {
       // Before looking at dst.length, make sure dst is also an objArray.
       __ lw(t0, Address(t2, lh_offset));
-      __ mvw(t1, objArray_lh);
+      __ mv(t1, objArray_lh);
       __ bne(t0, t1, L_failed);
 
       // It is safe to examine both src.length and dst.length.

--- a/src/hotspot/cpu/riscv32/vtableStubs_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/vtableStubs_riscv32.cpp
@@ -91,7 +91,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index) {
 
     // check offset vs vtable length
     __ lw(t0, Address(t2, Klass::vtable_length_offset()));
-    __ mvw(t1, vtable_index * vtableEntry::size());
+    __ mv(t1, vtable_index * vtableEntry::size());
     __ bgt(t0, t1, L);
     __ enter();
     __ mv(x12, vtable_index);


### PR DESCRIPTION
Mvw inst is useless and it is from the RV64G, so just
remove it and instead it with the mv inst.