### PR TITLE
Fix the slli error in load/store in long/double

### DIFF
--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -88,7 +88,7 @@ static inline Address iaddress(Register r,  Register temp, InterpreterMacroAssem
 static inline Address laddress(Register r, Register temp,
                                InterpreterMacroAssembler* _masm) {
   assert_cond(_masm != NULL);
-  _masm->slli(temp, r, 3);
+  _masm->slli(temp, r, 2);
   _masm->add(temp, xlocals, temp);
   return Address(temp, Interpreter::local_offset_in_bytes(1));;
 }
@@ -96,7 +96,7 @@ static inline Address laddress(Register r, Register temp,
 static inline Address haddress(Register r, Register temp,
                                InterpreterMacroAssembler* _masm) {
   assert_cond(_masm != NULL);
-  _masm->slli(temp, r, 3);
+  _masm->slli(temp, r, 2);
   _masm->add(temp, xlocals, temp);
   return Address(temp, Interpreter::local_offset_in_bytes(0));;
 }


### PR DESCRIPTION
The long/double is 64 bit in rv32g, so they need do some special wrok.
This patch fix two slli error in the templateTable_riscv32.cpp, it will make
we get the same error whether we print bytecode or not.