### PR TITLE
Fix the atomic insts

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -2318,7 +2318,9 @@ void MacroAssembler::atomic_##NAME(Register prev, RegisterOrConstant incr, Regis
 }
 
 ATOMIC_OP(add, amoadd_w, Assembler::relaxed, Assembler::relaxed)
+ATOMIC_OP(addw, amoadd_w, Assembler::relaxed, Assembler::relaxed)
 ATOMIC_OP(addal, amoadd_w, Assembler::aq, Assembler::rl)
+ATOMIC_OP(addalw, amoadd_w, Assembler::aq, Assembler::rl)
 
 #undef ATOMIC_OP
 
@@ -2330,19 +2332,20 @@ void MacroAssembler::atomic_##OP(Register prev, Register newv, Register addr) { 
 }
 
 ATOMIC_XCHG(xchg, amoswap_w, Assembler::relaxed, Assembler::relaxed)
+ATOMIC_XCHG(xchgw, amoswap_w, Assembler::relaxed, Assembler::relaxed)
 ATOMIC_XCHG(xchgal, amoswap_w, Assembler::aq, Assembler::rl)
+ATOMIC_XCHG(xchgalw, amoswap_w, Assembler::aq, Assembler::rl)
 
 #undef ATOMIC_XCHG
 
 #define ATOMIC_XCHGU(OP1, OP2)                                                       \
 void MacroAssembler::atomic_##OP1(Register prev, Register newv, Register addr) {     \
   atomic_##OP2(prev, newv, addr);                                                    \
-  clear_upper_bits(prev, 16);                                                        \
   return;                                                                            \
 }
 
-ATOMIC_XCHGU(xchgu, xchg)
-ATOMIC_XCHGU(xchgalu, xchgal)
+ATOMIC_XCHGU(xchgwu, xchgw)
+ATOMIC_XCHGU(xchgalwu, xchgalw)
 
 #undef ATOMIC_XCHGU
 

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -548,9 +548,11 @@ class MacroAssembler: public Assembler {
   void atomic_addalw(Register prev, RegisterOrConstant incr, Register addr);
 
   void atomic_xchg(Register prev, Register newv, Register addr);
+  void atomic_xchgw(Register prev, Register newv, Register addr);
   void atomic_xchgal(Register prev, Register newv, Register addr);
-  void atomic_xchgu(Register prev, Register newv, Register addr);
-  void atomic_xchgalu(Register prev, Register newv, Register addr);
+  void atomic_xchgalw(Register prev, Register newv, Register addr);
+  void atomic_xchgwu(Register prev, Register newv, Register addr);
+  void atomic_xchgalwu(Register prev, Register newv, Register addr);
 
   // Biased locking support
   // lock_reg and obj_reg must be loaded up with the appropriate values.

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -5622,10 +5622,10 @@ instruct get_and_setN(indirect mem, iRegN newv, iRegINoSp prev)
 
   ins_cost(ALU_COST);
 
-  format %{ "atomic_xchgu $prev, $newv, [$mem]\t#@get_and_setN" %}
+  format %{ "atomic_xchgwu $prev, $newv, [$mem]\t#@get_and_setN" %}
 
   ins_encode %{
-    __ atomic_xchgu($prev$$Register, $newv$$Register, as_Register($mem$$base));
+    __ atomic_xchgwu($prev$$Register, $newv$$Register, as_Register($mem$$base));
   %}
 
   ins_pipe(pipe_serial);
@@ -5688,10 +5688,10 @@ instruct get_and_setNAcq(indirect mem, iRegN newv, iRegINoSp prev)
 
   ins_cost(ALU_COST);
 
-  format %{ "atomic_xchgu_acq $prev, $newv, [$mem]\t#@get_and_setNAcq" %}
+  format %{ "atomic_xchgwu_acq $prev, $newv, [$mem]\t#@get_and_setNAcq" %}
 
   ins_encode %{
-    __ atomic_xchgalu($prev$$Register, $newv$$Register, as_Register($mem$$base));
+    __ atomic_xchgalwu($prev$$Register, $newv$$Register, as_Register($mem$$base));
   %}
 
   ins_pipe(pipe_serial);


### PR DESCRIPTION
Change the atomic inst to make them follow the RV64, just use the RV32 inst intead the RV64 inst.
This patch will make the atomic code clean and easy to understand.