### PR TITLE
Fix parameter passing of long type when calling native method.

### DIFF
--- a/src/hotspot/cpu/riscv32/interpreterRT_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/interpreterRT_riscv32.cpp
@@ -69,9 +69,11 @@ void InterpreterRuntime::SignatureHandlerGenerator::pass_int() {
 
 void InterpreterRuntime::SignatureHandlerGenerator::pass_long() {
   const Address src(from(), Interpreter::local_offset_in_bytes(offset() + 1));
+  const Address high(from(), Interpreter::local_offset_in_bytes(offset()));
 
   if (_num_int_args < Argument::n_int_register_parameters_c - 1) {
     __ lw(g_INTArgReg[++_num_int_args], src);
+    __ lw(g_INTArgReg[++_num_int_args], high);
   } else {
     __ lw(x10, src);
     __ sw(x10, Address(to(), _stack_offset));


### PR DESCRIPTION
Because it is RV32, when calling C++ method from JVM, two registers are needed to pass long type parameters.