### PR TITLE
Fix pop_l and lcmp

### DIFF
--- a/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
@@ -339,9 +339,11 @@ void InterpreterMacroAssembler::pop_i(Register r) {
   addi(esp, esp, wordSize);
 }
 
-void InterpreterMacroAssembler::pop_l(Register r) {
-  lw(r, Address(esp, 0));
-  lw(x11, Address(esp, wordSize));
+void InterpreterMacroAssembler::pop_l(Register lo, Register hi) {
+  assert_different_registers(lo, hi);
+  assert(lo < hi, "lo must be < hi");
+  lw(lo, Address(esp, 0));
+  lw(hi, Address(esp, wordSize));
   addi(esp, esp, 2 * wordSize);
 }
 

--- a/src/hotspot/cpu/riscv32/interp_masm_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/interp_masm_riscv32.hpp
@@ -125,7 +125,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
   void pop_ptr(Register r = x10);
   void pop_i(Register r = x10);
-  void pop_l(Register r = x10);
+  void pop_l(Register r1 = x10, Register r2 = x11);
   void pop_f(FloatRegister r = f10);
   void pop_d(FloatRegister r = f10);
   void push_ptr(Register r = x10);

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -4455,23 +4455,26 @@ void MacroAssembler::cmp_l2i(Register dst, Register src1, Register src2, Registe
     mv(dst, zr);
     return;
   }
-  Label done;
-  Register left = src1;
-  Register right = src2;
-  if (dst == src1) {
-    assert_different_registers(dst, src2, tmp);
-    mv(tmp, src1);
-    left = tmp;
-  } else if (dst == src2) {
-    assert_different_registers(dst, src1, tmp);
-    mv(tmp, src2);
-    right = tmp;
-  }
+  Label done_hi,done;
+  Register left_lo  = src1;
+  Register left_hi  = src1 + 1;
+  Register right_lo = src2;
+  Register right_hi = src2 + 1;
 
+  // compare high 32-bit
   // installs 1 if gt else 0
-  slt(dst, right, left);
+  slt(dst, right_hi, left_hi);
   bnez(dst, done);
-  slt(dst, left, right);
+  slt(dst, left_hi, right_hi);
+  // dst = -1 if lt; else if eq , jump to compare low 32-bit
+  neg(dst, dst);
+  bnez(dst, done);
+
+  // compare low 32-bit
+  // installs 1 if gt else 0
+  slt(dst, right_lo, left_lo);
+  bnez(dst, done);
+  slt(dst, left_lo, right_lo);
   // dst = -1 if lt; else if eq , dst = 0
   neg(dst, dst);
   bind(done);

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -4455,7 +4455,7 @@ void MacroAssembler::cmp_l2i(Register dst, Register src1, Register src2, Registe
     mv(dst, zr);
     return;
   }
-  Label done_hi,done;
+  Label done;
   Register left_lo  = src1;
   Register left_hi  = src1 + 1;
   Register right_lo = src2;

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -1055,9 +1055,9 @@ void TemplateTable::wide_istore() {
 void TemplateTable::wide_lstore() {
   transition(vtos, vtos);
   __ pop_l();
-  locals_index_wide(x12);
-  __ sw(x10, laddress(x12, t0, _masm));
-  __ sw(x11, haddress(x12, t0, _masm));
+  locals_index_wide(x13);
+  __ sw(x10, laddress(x13, t0, _masm));
+  __ sw(x11, haddress(x13, t0, _masm));
 }
 
 void TemplateTable::wide_fstore() {
@@ -1402,14 +1402,14 @@ void TemplateTable::lop2(Operation op)
 {
   transition(ltos, ltos);
   // x10 <== x11 op x10
-  __ pop_l(x11);
+  __ pop_l(x12, x13);
   switch (op) {
-  case add  : __ add(x10, x11, x10);  break;
-  case sub  : __ sub(x10, x11, x10);  break;
-  case mul  : __ mul(x10, x11, x10);  break;
-  case _and : __ andr(x10, x11, x10); break;
-  case _or  : __ orr(x10, x11, x10);  break;
-  case _xor : __ xorr(x10, x11, x10); break;
+  case add  : __ add(x10, x12, x10);  break;
+  case sub  : __ sub(x10, x12, x10);  break;
+  case mul  : __ mul(x10, x12, x10);  break;
+  case _and : __ andr(x10, x12, x10); break;
+  case _or  : __ orr(x10, x12, x10);  break;
+  case _xor : __ xorr(x10, x12, x10); break;
   default   : ShouldNotReachHere();
   }
 }
@@ -1445,8 +1445,8 @@ void TemplateTable::irem()
 void TemplateTable::lmul()
 {
   transition(ltos, ltos);
-  __ pop_l(x11);
-  __ mul(x10, x10, x11);
+  __ pop_l(x12, x13);
+  __ mul(x10, x10, x12);
 }
 
 void TemplateTable::ldiv()
@@ -1458,9 +1458,9 @@ void TemplateTable::ldiv()
   __ mv(t0, Interpreter::_throw_ArithmeticException_entry);
   __ jr(t0);
   __ bind(no_div0);
-  __ pop_l(x11);
+  __ pop_l(x12, x13);
   // x10 <== x11 ldiv x10
-  __ corrected_idivq(x10, x11, x10, /* want_remainder */ false);
+  __ corrected_idivq(x10, x12, x10, /* want_remainder */ false);
 }
 
 void TemplateTable::lrem()
@@ -1472,33 +1472,33 @@ void TemplateTable::lrem()
   __ mv(t0, Interpreter::_throw_ArithmeticException_entry);
   __ jr(t0);
   __ bind(no_div0);
-  __ pop_l(x11);
+  __ pop_l(x12, x13);
   // x10 <== x11 lrem x10
-  __ corrected_idivq(x10, x11, x10, /* want_remainder */ true);
+  __ corrected_idivq(x10, x12, x10, /* want_remainder */ true);
 }
 
 void TemplateTable::lshl()
 {
   transition(itos, ltos);
   // shift count is in x10
-  __ pop_l(x11);
-  __ sll(x10, x11, x10);
+  __ pop_l(x12, x13);
+  __ sll(x10, x12, x10);
 }
 
 void TemplateTable::lshr()
 {
   transition(itos, ltos);
   // shift count is in x10
-  __ pop_l(x11);
-  __ sra(x10, x11, x10);
+  __ pop_l(x12, x13);
+  __ sra(x10, x12, x10);
 }
 
 void TemplateTable::lushr()
 {
   transition(itos, ltos);
   // shift count is in x10
-  __ pop_l(x11);
-  __ srl(x10, x11, x10);
+  __ pop_l(x12, x13);
+  __ srl(x10, x12, x10);
 }
 
 void TemplateTable::fop2(Operation op)
@@ -1713,8 +1713,8 @@ void TemplateTable::convert()
 void TemplateTable::lcmp()
 {
   transition(ltos, itos);
-  __ pop_l(x11);
-  __ cmp_l2i(t0, x11, x10);
+  __ pop_l(x12, x13);
+  __ cmp_l2i(t0, x12, x10);
   __ mv(x10, t0);
 }
 
@@ -3038,7 +3038,7 @@ void TemplateTable::jvmti_post_fast_field_mod()
     case Bytecodes::_fast_iputfield: __ pop_i(x10); break;
     case Bytecodes::_fast_dputfield: __ pop_d(); break;
     case Bytecodes::_fast_fputfield: __ pop_f(); break;
-    case Bytecodes::_fast_lputfield: __ pop_l(x10); break;
+    case Bytecodes::_fast_lputfield: __ pop_l(); break;
     }
     __ bind(L2);
   }


### PR DESCRIPTION
Add register parms of pop_l in interp_masm_riscv32.cpp.
Change the declaration of pop_l in interp_masm_riscv32.hpp.
Change the parms of pop_l and register of the next instruction in templateTable_riscv32.cpp.
With the previous commit of pop_l fixed, add high 32-bit comparation of cmp_l2i in macroAssembler_riscv32.cpp.