### PR TITLE
Fix the nums of StackAlignmentInBytes

### DIFF
--- a/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
@@ -742,7 +742,7 @@ void InterpreterMacroAssembler::remove_activation(
   // adjusting SP to allow some space for ESP.  If we're returning to
   // compiled code the saved sender SP was saved in sender_sp, so this
   // restores it.
-  andi(sp, esp, -16);
+  andi(sp, esp, -8);
 }
 
 // Lock object

--- a/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
@@ -124,7 +124,7 @@ class RegisterSaver {
 
 OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_frame_words, int* total_frame_words) {
   assert_cond(masm != NULL && total_frame_words != NULL);
-  int frame_size_in_bytes = align_up(additional_frame_words * wordSize + reg_save_size * BytesPerInt, 16);
+  int frame_size_in_bytes = align_up(additional_frame_words * wordSize + reg_save_size * BytesPerInt, 8);
   // OopMap frame size is in compiler stack slots (jint's) not bytes or words
   int frame_size_in_slots = frame_size_in_bytes / BytesPerInt;
   // The caller will allocate additional_frame_words
@@ -184,7 +184,7 @@ void RegisterSaver::restore_result_registers(MacroAssembler* masm) {
   __ lw(x10, Address(sp, x10_offset_in_bytes()));
 
   // Pop all of the register save are off the stack
-  __ add(sp, sp, align_up(return_offset_in_bytes(), 16));
+  __ add(sp, sp, align_up(return_offset_in_bytes(), 8));
 }
 
 // Is vector's size (in bytes) bigger than a size saved by default?
@@ -486,7 +486,7 @@ void SharedRuntime::gen_i2c_adapter(MacroAssembler *masm,
   int comp_words_on_stack = align_up(comp_args_on_stack * VMRegImpl::stack_slot_size, wordSize) >> LogBytesPerWord;
   if (comp_args_on_stack != 0) {
     __ sub(t0, sp, comp_words_on_stack * wordSize);
-    __ andi(sp, t0, -16);
+    __ andi(sp, t0, -8);
   }
 
   // Will jump to the compiled code just as if compiled code was doing it.
@@ -2419,12 +2419,12 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   MacroAssembler* masm = new MacroAssembler(&buffer);
   assert_cond(masm != NULL);
 
-  assert(SimpleRuntimeFrame::framesize % 4 == 0, "sp not 16-byte aligned");
+  assert(SimpleRuntimeFrame::framesize % 4 == 0, "sp not 8-byte aligned");
 
   address start = __ pc();
 
   // Push self-frame.  We get here with a return address in LR
-  // and sp should be 16 byte aligned
+  // and sp should be 8 byte aligned
   // push fp and retaddr by hand
   __ addi(sp, sp, -2 * wordSize);
   __ sw(lr, Address(sp, wordSize));
@@ -2851,7 +2851,7 @@ void OptoRuntime::generate_exception_blob() {
   assert(!OptoRuntime::is_callee_saved_register(R10_num), "");
   assert(!OptoRuntime::is_callee_saved_register(R12_num), "");
 
-  assert(SimpleRuntimeFrame::framesize % 4 == 0, "sp not 16-byte aligned");
+  assert(SimpleRuntimeFrame::framesize % 4 == 0, "sp not 8-byte aligned");
 
   // Allocate space for the code
   ResourceMark rm;

--- a/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
@@ -2719,7 +2719,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ enter(); // Save FP and LR before call
 
-    assert(is_even(framesize / 2), "sp not 16-byte aligned");
+    assert(is_even(framesize / 2), "sp not 8-byte aligned");
 
     // lr and fp are already in place
     __ addi(sp, fp, 0 - (((unsigned)framesize - 4) << LogBytesPerInt)); // prolog

--- a/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
@@ -72,7 +72,7 @@ int TemplateInterpreter::InterpreterCodeSize = 256 * 1024;
 address TemplateInterpreterGenerator::generate_slow_signature_handler() {
   address entry = __ pc();
 
-  __ andi(esp, esp, -16);
+  __ andi(esp, esp, -8);
   __ mv(c_rarg3, esp);
   // xmethod
   // xlocals
@@ -467,7 +467,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
         Address(fp, frame::interpreter_frame_initial_sp_offset * wordSize));
   __ slli(t0, t0, 3);
   __ sub(t0, t1, t0);
-  __ andi(sp, t0, -16);
+  __ andi(sp, t0, -8);
 
  __ check_and_handle_popframe(xthread);
  __ check_and_handle_earlyret(xthread);
@@ -495,7 +495,7 @@ address TemplateInterpreterGenerator::generate_deopt_entry_for(TosState state,
   __ lw(t1, Address(fp, frame::interpreter_frame_initial_sp_offset * wordSize));
   __ slli(t0, t0, 3);
   __ sub(t0, t1, t0);
-  __ andi(sp, t0, -16);
+  __ andi(sp, t0, -8);
 
   // Restore expression stack pointer
   __ lw(esp, Address(fp, frame::interpreter_frame_last_sp_offset * wordSize));
@@ -712,7 +712,7 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
   // correct call stack that we can always unwind.  The ANDI should be
   // unnecessary because the sender SP in x30 is always aligned, but
   // it doesn't hurt.
-  __ andi(sp, x30, -16);
+  __ andi(sp, x30, -8);
 
   // Note: the restored frame is not necessarily interpreted.
   // Use the shared runtime version of the StackOverflowError.
@@ -853,7 +853,7 @@ void TemplateInterpreterGenerator::generate_fixed_frame(bool native_call) {
     __ add(t0, t0, frame::interpreter_frame_monitor_size() + 2);
     __ slli(t0, t0, 3);
     __ sub(t0, sp, t0);
-    __ andi(sp, t0, -16);
+    __ andi(sp, t0, -8);
   }
 }
 
@@ -916,7 +916,7 @@ address TemplateInterpreterGenerator::generate_Reference_get_entry(void) {
   bs->load_at(_masm, IN_HEAP | ON_WEAK_OOP_REF, T_OBJECT, local_0, field_address, /*tmp1*/ t1, /*tmp2*/ t0);
 
   // areturn
-  __ andi(sp, x9, -16);  // done with stack
+  __ andi(sp, x9, -8);  // done with stack
   __ ret();
 
   // generate a vanilla interpreter entry as the slow path
@@ -1008,7 +1008,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   __ addi(xlocals, xlocals, -wordSize);
 
   // Pull SP back to minimum size: this avoids holes in the stack
-  __ andi(sp, esp, -16);
+  __ andi(sp, esp, -8);
 
   // initialize fixed part of activation frame
   generate_fixed_frame(true);
@@ -1102,7 +1102,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
   __ slli(t, t, Interpreter::logStackElementSize);
   __ sub(x30, esp, t);
-  __ andi(sp, x30, -16);
+  __ andi(sp, x30, -8);
   __ mv(esp, x30);
 
   // get signature handler
@@ -1203,8 +1203,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // result potentially in x10 or f10
 
   // make room for the pushes we're about to do
-  __ sub(t0, esp, 4 * wordSize);
-  __ andi(sp, t0, -16);
+  __ sub(t0, esp, 2 * wordSize);
+  __ andi(sp, t0, -8);
 
   // NOTE: The order of these pushes is known to frame::interpreter_frame_result
   // in order to extract the result of a method call. If the order of these
@@ -1434,8 +1434,8 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   __ sub(t0, esp, t1);
 
   // Padding between locals and fixed part of activation frame to ensure
-  // SP is always 16-byte aligned.
-  __ andi(sp, t0, -16);
+  // SP is always 8-byte aligned.
+  __ andi(sp, t0, -8);
 
   // x13 - # of additional locals
   // allocate space for locals
@@ -1618,7 +1618,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   __ lw(t1, Address(fp, frame::interpreter_frame_initial_sp_offset * wordSize));
   __ slli(t0, t0, 2);
   __ sub(t0, t1, t0);
-  __ andi(sp, t0, -16);
+  __ andi(sp, t0, -8);
 
   // x10: exception handler entry point
   // x13: preserved exception oop
@@ -1750,7 +1750,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   __ lw(t1, Address(fp, frame::interpreter_frame_initial_sp_offset * wordSize));
   __ slli(t0, t0, 2);
   __ sub(t0, t1, t0);
-  __ andi(sp, t0, -16);
+  __ andi(sp, t0, -8);
 
   __ dispatch_next(vtos);
   // end of PopFrame support

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -1949,7 +1949,7 @@ void TemplateTable::branch(bool is_jsr, bool is_wide)
       // remove frame anchor
       __ leave();
       // Ensure compiled code always sees stack at proper alignment
-      __ andi(sp, esp, -16);
+      __ andi(sp, esp, -8);
 
       // and begin the OSR nmethod
       __ lw(t0, Address(x9, nmethod::osr_entry_point_offset()));

--- a/src/hotspot/cpu/riscv32/vtableStubs_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/vtableStubs_riscv32.cpp
@@ -113,7 +113,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index) {
   // lookup_virtual_method generates
   // 4 instructions (maximum value encountered in normal case):li(lui + addi) + add + lw
   // 1 instruction (best case):lw * 1
-  slop_delta = 16 - (int)(__ pc() - start_pc);
+  slop_delta = 8 - (int)(__ pc() - start_pc);
   slop_bytes += slop_delta;
   assert(slop_delta >= 0, "negative slop(%d) encountered, adjust code size estimate!", slop_delta);
 


### PR DESCRIPTION
The value of StackAlignmentInBytes has changed from 16 to 8. But some code still use the 16 as the bytes alignment of stack, this patch will fix the problems,change the 16 to 8.