### PR TITLE
Fix some move 48 bits

### DIFF
--- a/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
@@ -75,7 +75,7 @@ void InterpreterMacroAssembler::narrow(Register result) {
   bind(notByte);
   mv(t1, T_CHAR);
   bne(t0, t1, notChar);
-  zero_ext(result, result, registerSize - 16); // turncate upper 48 bits
+  zero_ext(result, result, registerSize - 16); // turncate upper 16 bits
   j(done);
 
   bind(notChar);

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1442,8 +1442,7 @@ void MacroAssembler::grevwu(Register Rd, Register Rs, Register Rtmp1, Register R
   assert_different_registers(Rs, Rtmp1, Rtmp2);
   assert_different_registers(Rd, Rtmp1, Rtmp2);
   grev16wu(Rd, Rs, Rtmp1, Rtmp2);
-  slli(Rtmp2, Rd, 48);
-  srli(Rtmp2, Rtmp2, 32);
+  slli(Rtmp2, Rd, 16);
   srli(Rd, Rd, 16);
   orr(Rd, Rd, Rtmp2);
 }

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -1669,10 +1669,9 @@ void TemplateTable::wide_iinc()
   transition(vtos, vtos);
   __ lw(x11, at_bcp(2)); // get constant and index
   __ grev16wu(x11, x11); // reverse bytes in half-word (32bit) and zero-extend
-  __ zero_ext(x12, x11, 48);
+  __ zero_ext(x12, x11, 16);
   __ neg(x12, x12);
-  __ slli(x11, x11, 32);
-  __ srai(x11, x11, 48);
+  __ srai(x11, x11, 16);
   __ lw(x10, iaddress(x12, t0, _masm));
   __ add(x10, x10, x11);
   __ sw(x10, iaddress(x12, t0, _masm));


### PR DESCRIPTION
In 64 bits version openjdk, they always need to move 48 bits to get 16 bits value. But in 32 bits, they just need to move 16 bits.
This patch will fix this problem.