### PR TITLE
fix lneg

### DIFF
--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -1640,6 +1640,7 @@ void TemplateTable::lneg()
 {
   transition(ltos, ltos);
   __ neg(x10, x10);
+  __ neg(x11, x11);
 }
 
 void TemplateTable::fneg()


### PR DESCRIPTION
The size of long in rv32 is 8, using x10 and x11 to save the long.Fix the lneg by adding neg(x11, x11).