### PR TITLE
Fix that the field data failed to be zeroed when creating the object.

### DIFF
--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -3765,8 +3765,8 @@ void TemplateTable::_new() {
       Label loop;
       __ bind(loop);
       __ sw(zr, Address(x12));
-      __ add(x12, x12, BytesPerLong);
-      __ sub(x13, x13, BytesPerLong);
+      __ add(x12, x12, BytesPerInt);
+      __ sub(x13, x13, BytesPerInt);
       __ bnez(x13, loop);
     }
 


### PR DESCRIPTION
Fix that the field data failed to be zeroed when creating the object.