### PR TITLE
Fix the assert error of BytesPerLong

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv32/copy_linux_riscv32.inline.hpp
+++ b/src/hotspot/os_cpu/linux_riscv32/copy_linux_riscv32.inline.hpp
@@ -87,8 +87,8 @@ static void pd_conjoint_jlongs_atomic(const jlong* from, jlong* to, size_t count
 }
 
 static void pd_conjoint_oops_atomic(const oop* from, oop* to, size_t count) {
-  assert(BytesPerLong == BytesPerOop, "jlongs and oops must be the same size.");
-  _Copy_conjoint_jlongs_atomic((const jlong*)from, (jlong*)to, count);
+  assert(BytesPerInt == BytesPerOop, "32-bit architecture");
+  _Copy_conjoint_jints_atomic((const jint*)from, (jint*)to, count);
 }
 
 static void pd_arrayof_conjoint_bytes(const HeapWord* from, HeapWord* to, size_t count) {


### PR DESCRIPTION
In the pd_conjoint_oops_atomic() function, there is an assert error of BytesPerLong,
this patch will fix this error according the implementation of arm.