### PR TITLE
Use int32 to instead some int64

### DIFF
--- a/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
@@ -154,7 +154,7 @@ class Address {
 
  private:
   Register _base;
-  int64_t _offset;
+  int32_t _offset;
   enum mode _mode;
 
   RelocationHolder _rspec;
@@ -519,7 +519,7 @@ public:
 #undef INSN
 
 #define INSN(NAME, op, funct3)                                                                           \
-  void NAME(Register Rs1, Register Rs2, const int64_t offset) {                                          \
+  void NAME(Register Rs1, Register Rs2, const int32_t offset) {                                          \
     unsigned insn = 0;                                                                                   \
     guarantee(is_imm_in_range(offset, 12, 1), "offset is invalid.");                                     \
     uint32_t val  = offset & 0x1fff;                                                                     \
@@ -539,7 +539,7 @@ public:
   }                                                                                                      \
   void NAME(Register Rs1, Register Rs2, const address dest) {                                            \
     assert_cond(dest != NULL);                                                                           \
-    int64_t offset = (dest - pc());                                                                      \
+    int32_t offset = (dest - pc());                                                                      \
     guarantee(is_imm_in_range(offset, 12, 1), "offset is invalid.");                                     \
     NAME(Rs1, Rs2, offset);                                                                              \
   }                                                                                                      \

--- a/src/hotspot/cpu/riscv32/icBuffer_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/icBuffer_riscv32.cpp
@@ -58,7 +58,7 @@ void InlineCacheBuffer::assemble_ic_buffer_code(address code_begin, void* cached
   __ far_jump(ExternalAddress(entry_point));
   __ align(wordSize);
   __ bind(l);
-  __ emit_int64((intptr_t)cached_value);
+  __ emit_int32((intptr_t)cached_value);
   // Only need to invalidate the 1st two instructions - not the whole ic stub
   ICache::invalidate_range(code_begin, InlineCacheBuffer::ic_stub_code_size());
   assert(__ pc() - start == ic_stub_code_size(), "must be");

--- a/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
@@ -2160,10 +2160,6 @@ class StubGenerator: public StubCodeGenerator {
         // int32_t
         __ lw(c_rarg1, Address(c_rarg0, 0));
         break;
-      case 8:
-        // int64_t
-        __ lw(c_rarg1, Address(c_rarg0, 0));
-        break;
       default:
         ShouldNotReachHere();
     }


### PR DESCRIPTION
Some data in RV32 is already 32bit, but their type are still int64, this patch
fix them.