### PR TITLE
Rv32g dev pushl

### DIFF
--- a/src/hotspot/cpu/riscv32/gc/shared/barrierSetAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/gc/shared/barrierSetAssembler_riscv32.cpp
@@ -66,7 +66,9 @@ void BarrierSetAssembler::load_at(MacroAssembler* masm, DecoratorSet decorators,
   case T_CHAR:    __ load_unsigned_short(dst, src); break;
   case T_SHORT:   __ load_signed_short  (dst, src); break;
   case T_INT:     __ lw                 (dst, src); break;
-  case T_LONG:    __ lw                 (dst, src); break;
+  case T_LONG:    __ lw(dst, src);
+                  __ lw(dst + 1, Address(src.base(), src.offset() + wordSize));
+                                                    break;
   case T_ADDRESS: __ lw                 (dst, src); break;
   case T_FLOAT:   __ flw                (f10, src); break;
   case T_DOUBLE:  __ fld                (f10, src); break;
@@ -107,7 +109,9 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
   case T_CHAR:    __ sh(val, dst); break;
   case T_SHORT:   __ sh(val, dst); break;
   case T_INT:     __ sw(val, dst); break;
-  case T_LONG:    __ sw(val, dst); break;
+  case T_LONG:    __ sw(val, dst);
+                  __ sw(val + 1, Address(dst.base(), dst.offset() + wordSize));
+                                   break;
   case T_ADDRESS: __ sw(val, dst); break;
   case T_FLOAT:   __ fsw(f10,  dst); break;
   case T_DOUBLE:  __ fsd(f10,  dst); break;

--- a/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
@@ -358,10 +358,10 @@ void InterpreterMacroAssembler::push_i(Register r) {
   sw(r, Address(esp, 0));
 }
 
-void InterpreterMacroAssembler::push_l(Register r) {
+void InterpreterMacroAssembler::push_l(Register lo, Register hi) {
   addi(esp, esp, -2 * wordSize);
-  sw(zr, Address(esp, wordSize));
-  sw(r, Address(esp));
+  sw(hi, Address(esp, wordSize));
+  sw(lo, Address(esp));
 }
 
 void InterpreterMacroAssembler::pop_f(FloatRegister r) {
@@ -591,6 +591,9 @@ void InterpreterMacroAssembler::remove_activation(
   // result check if synchronized method
   Label unlocked, unlock, no_unlock;
 
+  // store value of x11
+  mv(x15, x11);
+
   // get the value of _do_not_unlock_if_synchronized into x13
   const Address do_not_unlock_if_synchronized(xthread,
     in_bytes(JavaThread::do_not_unlock_if_synchronized_offset()));
@@ -738,6 +741,8 @@ void InterpreterMacroAssembler::remove_activation(
   }
   // remove frame anchor
   leave();
+  // restore value of x11
+  mv(x11, x15);
   // If we're returning to interpreted code we will shortly be
   // adjusting SP to allow some space for ESP.  If we're returning to
   // compiled code the saved sender SP was saved in sender_sp, so this

--- a/src/hotspot/cpu/riscv32/interp_masm_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/interp_masm_riscv32.hpp
@@ -130,7 +130,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void pop_d(FloatRegister r = f10);
   void push_ptr(Register r = x10);
   void push_i(Register r = x10);
-  void push_l(Register r = x10);
+  void push_l(Register r1 = x10, Register r2 = x11);
   void push_f(FloatRegister r = f10);
   void push_d(FloatRegister r = f10);
 

--- a/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateInterpreterGenerator_riscv32.cpp
@@ -452,11 +452,11 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   }
 
   // Pop N words from the stack
-  __ get_cache_and_index_at_bcp(x11, x12, 1, index_size);
-  __ lw(x11, Address(x11, ConstantPoolCache::base_offset() + ConstantPoolCacheEntry::flags_offset()));
-  __ andi(x11, x11, ConstantPoolCacheEntry::parameter_size_mask);
+  __ get_cache_and_index_at_bcp(x13, x12, 1, index_size);
+  __ lw(x13, Address(x13, ConstantPoolCache::base_offset() + ConstantPoolCacheEntry::flags_offset()));
+  __ andi(x13, x13, ConstantPoolCacheEntry::parameter_size_mask);
 
-  __ slli(t0, x11, 2);
+  __ slli(t0, x13, 2);
   __ add(esp, esp, t0);
 
   // Restore machine SP

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -473,7 +473,7 @@ void TemplateTable::ldc2_w()
     __ add(x10, x11, x10);
     __ lw(x11, Address(x10, base_offset + wordSize));
     __ lw(x10, Address(x10, base_offset));
-    __ push_l(x10);
+    __ push_l(x10, x11);
     __ j(Done);
 
     __ bind(notLong);
@@ -797,7 +797,6 @@ void TemplateTable::laload()
   __ slli(t0, x11, 3);
   __ add(t0, t0, x10);
   __ access_load_at(T_LONG, IN_HEAP | IS_ARRAY, x10, Address(t0), noreg, noreg);
-  __ access_load_at(T_LONG, IN_HEAP | IS_ARRAY, x11, Address(t0, wordSize), noreg, noreg);
 }
 
 void TemplateTable::faload()
@@ -1109,7 +1108,6 @@ void TemplateTable::lastore() {
   __ slli(t0, x12, 3);
   __ add(t0, x13, t0);
   __ access_store_at(T_LONG, IN_HEAP | IS_ARRAY, Address(t0, 0), x10, noreg, noreg);
-  __ access_store_at(T_LONG, IN_HEAP | IS_ARRAY, Address(t0, wordSize), x11, noreg, noreg);
 }
 
 void TemplateTable::fastore() {
@@ -3082,7 +3080,7 @@ void TemplateTable::jvmti_post_fast_field_mod()
     case Bytecodes::_fast_iputfield: __ push_i(x10); break;
     case Bytecodes::_fast_dputfield: __ push_d(); break;
     case Bytecodes::_fast_fputfield: __ push_f(); break;
-    case Bytecodes::_fast_lputfield: __ push_l(x10); break;
+    case Bytecodes::_fast_lputfield: __ push_l(x10, x11); break;
 
     default:
       ShouldNotReachHere();
@@ -3123,7 +3121,7 @@ void TemplateTable::fast_storefield(TosState state)
   jvmti_post_fast_field_mod();
 
   // access constant pool cache
-  __ get_cache_and_index_at_bcp(x12, x11, 1);
+  __ get_cache_and_index_at_bcp(x12, x14, 1);
 
   // Must prevent reordering of the following cp cache loads with bytecode load
   __ membar(MacroAssembler::LoadLoad);
@@ -3133,7 +3131,7 @@ void TemplateTable::fast_storefield(TosState state)
                                     ConstantPoolCacheEntry::flags_offset())));
 
   // replace index with field offset from cache entry
-  __ lw(x11, Address(x12, in_bytes(base + ConstantPoolCacheEntry::f2_offset())));
+  __ lw(x14, Address(x12, in_bytes(base + ConstantPoolCacheEntry::f2_offset())));
 
   {
     Label notVolatile;
@@ -3149,8 +3147,8 @@ void TemplateTable::fast_storefield(TosState state)
   pop_and_check_object(x12);
 
   // field address
-  __ add(x11, x12, x11);
-  const Address field(x11, 0);
+  __ add(x14, x12, x14);
+  const Address field(x14, 0);
 
   // access field
   switch (bytecode()) {

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -1731,7 +1731,7 @@ void TemplateTable::convert()
   // Conversion
   switch (bytecode()) {
   case Bytecodes::_i2l:
-    __ sign_ext(x10, x10, registerSize - 32);
+    __ srai(x11, x10, 0x1f);
     break;
   case Bytecodes::_i2f:
     __ fcvt_s_w(f10, x10);


### PR DESCRIPTION
Merge the rv32g-dev-pushl branch into the rv32g-dev. The  rv32g-dev-pushl branch fix the problem about pushl and some errors based the pushl. 

The  rv32g-dev-pushl branch can run the java -version on the fastdebug and slowdebug.