### PR TITLE
Expand BUFFER_SIZE in jniFastGetField_riscv32.cpp

### DIFF
--- a/src/hotspot/cpu/riscv32/jniFastGetField_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/jniFastGetField_riscv32.cpp
@@ -36,7 +36,7 @@
 
 #define __ masm->
 
-#define BUFFER_SIZE 30*wordSize
+#define BUFFER_SIZE 60 * wordSize
 
 // Instead of issuing a LoadLoad barrier we create an address
 // dependency between loads; this might be more efficient.


### PR DESCRIPTION
Expand BUFFER_SIZE in jniFastGetField_riscv32.cpp, to fix exceptions in codeBuffer.cpp when the release version is running.