### PR TITLE
Fix the patch_addr_in_movptr and get_target_of_movptr

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1195,7 +1195,7 @@ static int patch_addr_in_movptr(address branch, address target) {
   const int MOVPTR_INSTRUCTIONS_NUM = 2;                                                  // lui + addi
   int32_t lower = ((intptr_t)target << 20) >> 20;
   int32_t upper = (intptr_t)target >> 12;
-  Assembler::patch(branch,  31, 12, upper);                       // Lui.             target[31:12] ==> branch[31:12]
+  Assembler::patch(branch,  31, 12, upper);                           // Lui.             target[31:12] ==> branch[31:12]
   Assembler::patch(branch + 4,  31, 20, lower);                       // Addi.            target[11: 0] ==> branch[31:20]
   return MOVPTR_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
 }


### PR DESCRIPTION
The patch_addr_in_movptr() give a wrong addr to the patch(), it will cause a internal error in patch(), which
is the val too big for insn.
The get_target_of_movptr() still is 64bit version, need to improve to 32bit version.