### PR TITLE
Fix the error of java -version when use 'make'

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1204,7 +1204,7 @@ static int patch_imm_in_li(address branch, int32_t target) {
   const int LI32_INSTRUCTIONS_NUM = 2;                                          // lui + addi
   int32_t lower = ((intptr_t)target << 20) >> 20;
   int32_t upper = (intptr_t)target >> 12;
-  Assembler::patch(branch + 0,  31, 12, (upper >> 12) & 0xfffff);               // Lui.
+  Assembler::patch(branch + 0,  31, 12, upper & 0xfffff);                       // Lui.
   Assembler::patch(branch + 4,  31, 20, lower & 0xfff);                         // Addi.
   return LI32_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
 }

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1204,7 +1204,7 @@ static int patch_imm_in_li(address branch, int32_t target) {
   const int LI32_INSTRUCTIONS_NUM = 2;                                          // lui + addi
   int32_t lower = ((intptr_t)target << 20) >> 20;
   int32_t upper = (intptr_t)target >> 12;
-  Assembler::patch(branch + 0,  31, 12, upper & 0xfffff);                       // Lui.
+  Assembler::patch(branch,  31, 12, upper & 0xfffff);                           // Lui.
   Assembler::patch(branch + 4,  31, 20, lower & 0xfff);                         // Addi.
   return LI32_INSTRUCTIONS_NUM * NativeInstruction::instruction_size;
 }


### PR DESCRIPTION
Whe use 'make' not 'make images', the 'java -version' will give us 'Field too big for insn' error in
patch(). According the error info, we need fix the data patch and get in the movptr and li.

This patch update the patch_addr_in_movptr(),patch_imm_in_li(),get_target_of_movptr()andget_target_of_li(),
the update all about the data and insn position.

After this patch, the 'make' and 'make images' will get the same result.