### PR TITLE
Fix configure integration

### DIFF
--- a/make/autoconf/build-aux/autoconf-config.guess
+++ b/make/autoconf/build-aux/autoconf-config.guess
@@ -1000,9 +1000,6 @@ EOF
     ppc:Linux:*:*)
 	echo powerpc-unknown-linux-gnu
 	exit ;;
-    riscv32:Linux:*:*)
-	echo riscv32-unknown-linux-gnu
-	exit ;;
     s390:Linux:*:* | s390x:Linux:*:*)
 	echo ${UNAME_MACHINE}-ibm-linux
 	exit ;;

--- a/make/autoconf/build-aux/autoconf-config.sub
+++ b/make/autoconf/build-aux/autoconf-config.sub
@@ -302,7 +302,6 @@ case $basic_machine in
 	| pdp10 | pdp11 | pj | pjl \
 	| powerpc | powerpc64 | powerpc64le | powerpcle | ppcbe \
 	| pyramid \
-	| riscv32 \
 	| score \
 	| sh | sh[1234] | sh[24]a | sh[23]e | sh[34]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
 	| sh64 | sh64le \
@@ -384,7 +383,6 @@ case $basic_machine in
 	| pdp10-* | pdp11-* | pj-* | pjl-* | pn-* | power-* \
 	| powerpc-* | powerpc64-* | powerpc64le-* | powerpcle-* | ppcbe-* \
 	| pyramid-* \
-	| riscv32-* \
 	| romp-* | rs6000-* \
 	| sh-* | sh[1234]-* | sh[24]a-* | sh[23]e-* | sh[34]eb-* | sheb-* | shbe-* \
 	| shle-* | sh[1234]le-* | sh3ele-* | sh64-* | sh64le-* \

--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -104,4 +104,13 @@ if test $? = 0; then
   OUT=$REAL_CPU`echo $OUT | sed -e 's/[^-]*//'`
 fi
 
+# Test and fix RISC-V 32Bit.
+if [ "x$OUT" = x ]; then
+  if [ `uname -s` = Linux ]; then
+    if [ `uname -m` = riscv32 ]; then
+      OUT=riscv32-unknown-linux-gnu
+    fi
+  fi
+fi
+
 echo $OUT


### PR DESCRIPTION
With reference to https://bugs.openjdk.java.net/browse/JDK-8283020, there is the same issue on the riscv32 platform.
This patch will remove some modification about autoconf-* files due to legal reasons.