### PR TITLE
Modify the RISCV32 name system and improve the thread code

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1825,8 +1825,8 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
 #ifndef EM_AARCH64
   #define EM_AARCH64    183               /* ARM AARCH64 */
 #endif
-#ifndef EM_RISCV32
-  #define EM_RISCV32      243               /* RISC-V */
+#ifndef EM_RISCV
+  #define EM_RISCV      243               /* RISC-V */
 #endif
 
   static const arch_t arch_array[]={
@@ -1853,7 +1853,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     {EM_PARISC,      EM_PARISC,  ELFCLASS32, ELFDATA2MSB, (char*)"PARISC"},
     {EM_68K,         EM_68K,     ELFCLASS32, ELFDATA2MSB, (char*)"M68k"},
     {EM_AARCH64,     EM_AARCH64, ELFCLASS64, ELFDATA2LSB, (char*)"AARCH64"},
-    {EM_RISCV32,     EM_RISCV32, ELFCLASS32, ELFDATA2LSB, (char*)"RISCV32"},
+    {EM_RISCV,       EM_RISCV,   ELFCLASS32, ELFDATA2LSB, (char*)"RISCV32"},
   };
 
 #if  (defined IA32)
@@ -1889,7 +1889,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
 #elif  (defined SH)
   static  Elf32_Half running_arch_code=EM_SH;
 #elif  (defined RISCV32)
-  static  Elf32_Half running_arch_code=EM_RISCV32;
+  static  Elf32_Half running_arch_code=EM_RISCV;
 #else
     #error Method os::dll_load requires that one of following is defined:\
         AARCH64, ALPHA, ARM, AMD64, IA32, IA64, M68K, MIPS, MIPSEL, PARISC, __powerpc__, __powerpc64__, RISCV32, S390, SH, __sparc

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1825,8 +1825,8 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
 #ifndef EM_AARCH64
   #define EM_AARCH64    183               /* ARM AARCH64 */
 #endif
-#ifndef EM_RISCV
-  #define EM_RISCV      243               /* RISC-V */
+#ifndef EM_RISCV32
+  #define EM_RISCV32      243               /* RISC-V */
 #endif
 
   static const arch_t arch_array[]={
@@ -1853,7 +1853,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     {EM_PARISC,      EM_PARISC,  ELFCLASS32, ELFDATA2MSB, (char*)"PARISC"},
     {EM_68K,         EM_68K,     ELFCLASS32, ELFDATA2MSB, (char*)"M68k"},
     {EM_AARCH64,     EM_AARCH64, ELFCLASS64, ELFDATA2LSB, (char*)"AARCH64"},
-    {EM_RISCV,       EM_RISCV,   ELFCLASS32, ELFDATA2LSB, (char*)"RISCV 32"},
+    {EM_RISCV32,     EM_RISCV32, ELFCLASS32, ELFDATA2LSB, (char*)"RISCV32"},
   };
 
 #if  (defined IA32)
@@ -1889,7 +1889,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
 #elif  (defined SH)
   static  Elf32_Half running_arch_code=EM_SH;
 #elif  (defined RISCV32)
-  static  Elf32_Half running_arch_code=EM_RISCV;
+  static  Elf32_Half running_arch_code=EM_RISCV32;
 #else
     #error Method os::dll_load requires that one of following is defined:\
         AARCH64, ALPHA, ARM, AMD64, IA32, IA64, M68K, MIPS, MIPSEL, PARISC, __powerpc__, __powerpc64__, RISCV32, S390, SH, __sparc

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1217,19 +1217,9 @@ class JavaThread: public Thread {
   address last_Java_pc(void)                     { return _anchor.last_Java_pc(); }
 
   // Safepoint support
-#if !(defined(PPC64) || defined(AARCH64) || defined(RISCV32))
-  JavaThreadState thread_state() const           { return _thread_state; }
-  void set_thread_state(JavaThreadState s)       {
-    assert(current_or_null() == NULL || current_or_null() == this,
-           "state change should only be called by the current thread");
-    _thread_state = s;
-  }
-#else
-  // Use membars when accessing volatile _thread_state. See
-  // Threads::create_vm() for size checks.
   inline JavaThreadState thread_state() const;
   inline void set_thread_state(JavaThreadState s);
-#endif
+
   ThreadSafepointState *safepoint_state() const  { return _safepoint_state; }
   void set_safepoint_state(ThreadSafepointState *state) { _safepoint_state = state; }
   bool is_at_poll_safepoint()                    { return _safepoint_state->is_at_poll_safepoint(); }

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -120,15 +120,23 @@ inline void JavaThread::set_pending_async_exception(oop e) {
   set_has_async_exception();
 }
 
-#if defined(PPC64) || defined(AARCH64) || defined(RISCV32)
 inline JavaThreadState JavaThread::thread_state() const    {
+#if defined(PPC64) || defined(AARCH64) || defined(RISCV32)
   return (JavaThreadState) OrderAccess::load_acquire((volatile jint*)&_thread_state);
+#else
+  return _thread_state;
+#endif
 }
 
 inline void JavaThread::set_thread_state(JavaThreadState s) {
+  assert(current_or_null() == NULL || current_or_null() == this,
+         "state change should only be called by the current thread");
+#if defined(PPC64) || defined(AARCH64) || defined(RISCV32)
   OrderAccess::release_store((volatile jint*)&_thread_state, (jint)s);
-}
+#else
+  _thread_state = s;
 #endif
+}
 
 inline void JavaThread::set_done_attaching_via_jni() {
   _jni_attach_state = _attached_via_jni;


### PR DESCRIPTION
Modify the RISCV32 name system accoriding the AARCH64.
Improve the thread code in thread.hpp and thread.inline.hpp according the
http://hg.openjdk.java.net/jdk/jdk/rev/c153b4c52e39 .
After this commit, the make of slowdebug version can compiled success, but when run the
java -version, it still have the thread error. The error is same as the 'make images' of
slowdebug compiling.