### PR TITLE
Fix spillu/unspill/unspillu in C2

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -617,34 +617,20 @@ class MacroAssembler: public Assembler {
   #define call_Unimplemented() _call_Unimplemented((address)__PRETTY_FUNCTION__)
 
 #ifdef COMPILER2
-  void spill(Register Rx, bool is32, int offset) {
-    if (is32) {
-      sw(Rx, Address(sp, offset));
-    }
+  void spill(Register Rx, int offset) {
+    sw(Rx, Address(sp, offset));
   }
 
-  void spill(FloatRegister Rx, bool is32, int offset) {
-    if (is32) {
-      fsw(Rx, Address(sp, offset));
-    }
+  void spill(FloatRegister Rx, int offset) {
+    fsw(Rx, Address(sp, offset));
   }
 
-  void unspill(Register Rx, bool is32, int offset) {
-    if (is32) {
-      lw(Rx, Address(sp, offset));
-    }
+  void unspill(Register Rx, int offset) {
+    lw(Rx, Address(sp, offset));
   }
 
-  void unspillu(Register Rx, bool is32, int offset) {
-    if (is32) {
-      lw(Rx, Address(sp, offset));
-    }
-  }
-
-  void unspill(FloatRegister Rx, bool is32, int offset) {
-    if (is32) {
-      flw(Rx, Address(sp, offset));
-    }
+  void unspill(FloatRegister Rx, int offset) {
+    flw(Rx, Address(sp, offset));
   }
 #endif // COMPILER2
 

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -1185,7 +1185,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
             as_Register(Matcher::_regEncode[src_lo]));
       } else {                    // gpr --> stack spill
         assert(dst_lo_rc == rc_stack, "spill to bad register class");
-        __ spill(as_Register(Matcher::_regEncode[src_lo]), is64, dst_offset);
+        __ spill(as_Register(Matcher::_regEncode[src_lo]), dst_offset);
       }
       break;
     case rc_float:
@@ -1202,28 +1202,18 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
         }
       } else {                    // fpr --> stack spill
         assert(dst_lo_rc == rc_stack, "spill to bad register class");
-        __ spill(as_FloatRegister(Matcher::_regEncode[src_lo]),
-                 is64, dst_offset);
+        __ spill(as_FloatRegister(Matcher::_regEncode[src_lo]), dst_offset);
       }
       break;
     case rc_stack:
       if (dst_lo_rc == rc_int) {  // stack --> gpr load
-        if (this->ideal_reg() == Op_RegI) {
-          __ unspill(as_Register(Matcher::_regEncode[dst_lo]), is64, src_offset);
-        } else { // // zero extended for narrow oop or klass
-          __ unspillu(as_Register(Matcher::_regEncode[dst_lo]), is64, src_offset);
-        }
+        __ unspill(as_Register(Matcher::_regEncode[dst_lo]), src_offset);
       } else if (dst_lo_rc == rc_float) { // stack --> fpr load
-        __ unspill(as_FloatRegister(Matcher::_regEncode[dst_lo]),
-                   is64, src_offset);
+        __ unspill(as_FloatRegister(Matcher::_regEncode[dst_lo]), src_offset);
       } else {                    // stack --> stack copy
         assert(dst_lo_rc == rc_stack, "spill to bad register class");
-        if (this->ideal_reg() == Op_RegI) {
-          __ unspill(t0, is64, src_offset);
-        } else { // zero extended for narrow oop or klass
-          __ unspillu(t0, is64, src_offset);
-        }
-        __ spill(t0, is64, dst_offset);
+        __ unspill(t0, src_offset);
+        __ spill(t0, dst_offset);
       }
       break;
     default:


### PR DESCRIPTION
* Since 'is64' is always false in riscv32, remove parameter 'is64' in spillu/unspill/unspillu.

* The operations of 'unspillu' are exactly the same with 'unspill', so remove 'unspill'.

This patch has no effect on the current results.