### PR TITLE
Fix is64 in riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -1232,7 +1232,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
     if (bottom_type() == NULL || bottom_type()->isa_vect() != NULL) {
       ShouldNotReachHere();
     } else {
-      st->print("\t# spill size = %d", is64 ? 64 : 32);
+      st->print("\t# spill size = %d", 32);
     }
   }
 


### PR DESCRIPTION
Since is64 is always false in riscv32, remove parameter 'is64' in 'st->print'.