### PR TITLE
Revert 'is64' in riscv32.ad and macroAssembler_riscv32.hpp

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -621,16 +621,24 @@ class MacroAssembler: public Assembler {
     sw(Rx, Address(sp, offset));
   }
 
-  void spill(FloatRegister Rx, int offset) {
-    fsw(Rx, Address(sp, offset));
+  void spill(FloatRegister Rx, bool is64, int offset) {
+    if (is64) {
+      fsd(Rx, Address(sp, offset));
+    } else {
+      fsw(Rx, Address(sp, offset));
+    }
   }
 
   void unspill(Register Rx, int offset) {
     lw(Rx, Address(sp, offset));
   }
 
-  void unspill(FloatRegister Rx, int offset) {
-    flw(Rx, Address(sp, offset));
+  void unspill(FloatRegister Rx, bool is64, int offset) {
+    if (is64) {
+      fld(Rx, Address(sp, offset));
+    } else {
+      flw(Rx, Address(sp, offset));
+    }
   }
 #endif // COMPILER2
 

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -1139,6 +1139,8 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
     return 0;            // Self copy, no move.
   }
 
+  bool is64 = (src_lo & 1) == 0 && src_lo + 1 == src_hi &&
+              (dst_lo & 1) == 0 && dst_lo + 1 == dst_hi;
   int src_offset = ra_->reg2offset(src_lo);
   int dst_offset = ra_->reg2offset(dst_lo);
 
@@ -1166,18 +1168,25 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
         __ fmv_x_w(as_Register(Matcher::_regEncode[dst_lo]),
             as_FloatRegister(Matcher::_regEncode[src_lo]));
       } else if (dst_lo_rc == rc_float) { // fpr --> fpr copy
-        __ fmv_s(as_FloatRegister(Matcher::_regEncode[dst_lo]),
-            as_FloatRegister(Matcher::_regEncode[src_lo]));
+          if (is64) {
+            __ fmv_d(as_FloatRegister(Matcher::_regEncode[dst_lo]),
+                     as_FloatRegister(Matcher::_regEncode[src_lo]));
+        } else {
+            __ fmv_s(as_FloatRegister(Matcher::_regEncode[dst_lo]),
+                     as_FloatRegister(Matcher::_regEncode[src_lo]));
+        }
       } else {                    // fpr --> stack spill
         assert(dst_lo_rc == rc_stack, "spill to bad register class");
-        __ spill(as_FloatRegister(Matcher::_regEncode[src_lo]), dst_offset);
+        __ spill(as_FloatRegister(Matcher::_regEncode[src_lo]),
+                 is64, dst_offset);
       }
       break;
     case rc_stack:
       if (dst_lo_rc == rc_int) {  // stack --> gpr load
         __ unspill(as_Register(Matcher::_regEncode[dst_lo]), src_offset);
       } else if (dst_lo_rc == rc_float) { // stack --> fpr load
-        __ unspill(as_FloatRegister(Matcher::_regEncode[dst_lo]), src_offset);
+        __ unspill(as_FloatRegister(Matcher::_regEncode[dst_lo]),
+                   is64, src_offset);
       } else {                    // stack --> stack copy
         assert(dst_lo_rc == rc_stack, "spill to bad register class");
         __ unspill(t0, src_offset);
@@ -1205,7 +1214,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
     if (bottom_type() == NULL || bottom_type()->isa_vect() != NULL) {
       ShouldNotReachHere();
     } else {
-      st->print("\t# spill size = %d", 32);
+      st->print("\t# spill size = %d", is64 ? 64 : 32);
     }
   }
 


### PR DESCRIPTION
* Since the floating-point register needs to determine whether it is a 64-bit operation, revert the judgment of 'is64'.