### PR TITLE
Fix Matcher::isSimpleConstant64 on riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -1416,8 +1416,8 @@ bool Matcher::is_short_branch_offset(int rule, int br_size, int offset) {
 
 const bool Matcher::isSimpleConstant64(jlong value) {
   // Will one (StoreL ConL) be cheaper than two (StoreI ConI)?.
-  // Probably always true, even if a temp register is required.
-  return true;
+  // Probably always false, due to a temp register is required.
+  return false;
 }
 
 // true just means we have fast l2f conversion


### PR DESCRIPTION
Long data processing requires two registers to operate simultaneously, so one (StoreL ConL) be not cheaper than two (StoreI ConI). Fix the return value be false.