### PR TITLE
Fix incorrect register mask in call_native_base according to JDK-8285303

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -573,25 +573,14 @@ void MacroAssembler::emit_static_call_stub() {
 void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        int number_of_arguments,
                                        Label *retaddr) {
-  call_native_base(entry_point, retaddr);
-  ifence();
-}
-
-void MacroAssembler::call_native(address entry_point, Register arg_0) {
-  pass_arg0(this, arg_0);
-  call_native_base(entry_point);
-}
-
-void MacroAssembler::call_native_base(address entry_point, Label *retaddr) {
-  Label E, L;
   int32_t offset = 0;
-  push_reg(0x80000040, sp);   // push << t0 & xmethod >> to sp
+  push_reg(RegSet::of(t0, xmethod), sp);   // push << t0 & xmethod >> to sp
   lui(t0, (int32_t)entry_point + 0x800);
   jalr(x1, t0, ((int32_t)entry_point<<20)>>20);
   if (retaddr != NULL) {
     bind(*retaddr);
   }
-  pop_reg(0x80000040, sp);   // pop << t0 & xmethod >> from sp
+  pop_reg(RegSet::of(t0, xmethod), sp);   // pop << t0 & xmethod >> from sp
 }
 
 void MacroAssembler::call_VM_leaf(address entry_point, int number_of_arguments) {

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -145,13 +145,6 @@ class MacroAssembler: public Assembler {
   // thread in the default location (xthread)
   void reset_last_Java_frame(bool clear_fp);
 
-  void call_native(address entry_point,
-                   Register arg_0);
-  void call_native_base(
-    address entry_point,                // the entry point
-    Label*  retaddr = NULL
-  );
-
   virtual void call_VM_leaf_base(
     address entry_point,                // the entry point
     int     number_of_arguments,        // the number of arguments to pop after the call


### PR DESCRIPTION
* Register mask of '0x80000040' operates << t1 & xmethod >> here, which should be '0x80000020' for << t0 & xmethod >>.

* This PR also removes MacroAssembler::call_native_base and MacroAssembler::call_native_base, expands the definitions of call_native_base to MacroAssembler::call_VM_leaf_base directly.

Co-authored-by: Feilong Jiang <fjiang@openjdk.org>