### PR TITLE
Fix slots number in register/vmreg and processing of long in sharedRuntime

### DIFF
--- a/src/hotspot/cpu/riscv32/register_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/register_riscv32.cpp
@@ -27,7 +27,7 @@
 #include "precompiled.hpp"
 #include "register_riscv32.hpp"
 
-const int ConcreteRegisterImpl::max_gpr = RegisterImpl::number_of_registers << 1;
+const int ConcreteRegisterImpl::max_gpr = RegisterImpl::number_of_registers;
 
 const int ConcreteRegisterImpl::max_fpr
   = ConcreteRegisterImpl::max_gpr + (FloatRegisterImpl::number_of_registers << 1);

--- a/src/hotspot/cpu/riscv32/register_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/register_riscv32.hpp
@@ -52,7 +52,7 @@ class RegisterImpl: public AbstractRegisterImpl {
   enum {
     number_of_registers      = 32,
     number_of_byte_registers = 32,
-    max_slots_per_register   = 2
+    max_slots_per_register   = 1
   };
 
   // derived registers, offsets, and addresses

--- a/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
@@ -255,7 +255,7 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
 
   uint int_args = 0;
   uint fp_args = 0;
-  uint stk_args = 0; // inc by 2 each time
+  uint stk_args = 0;
 
   for (int i = 0; i < total_args_passed; i++) {
     switch (sig_bt[i]) {
@@ -264,11 +264,13 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
     case T_BYTE:
     case T_SHORT:
     case T_INT:
+    case T_ARRAY:
+    case T_OBJECT:
+    case T_ADDRESS:
       if (int_args < Argument::n_int_register_parameters_j) {
         regs[i].set1(INT_ArgReg[int_args++]->as_VMReg());
       } else {
-        regs[i].set1(VMRegImpl::stack2reg(stk_args));
-        stk_args += 2;
+        regs[i].set1(VMRegImpl::stack2reg(stk_args++));
       }
       break;
     case T_VOID:
@@ -277,18 +279,16 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
       regs[i].set_bad();
       break;
     case T_LONG:
-      assert((i + 1) < total_args_passed && sig_bt[i + 1] == T_VOID, "expecting half");
-      // fall through
-    case T_OBJECT:
-    case T_ARRAY:
-    case T_ADDRESS:
-      if (int_args < Argument::n_int_register_parameters_j) {
-        regs[i].set2(INT_ArgReg[int_args++]->as_VMReg());
+      if (int_args < Argument::n_int_register_parameters_j - 1) {
+        if (int_args & 1) int_args++;
+        regs[i].set_pair(INT_ArgReg[int_args + 1]->as_VMReg(), INT_ArgReg[int_args]->as_VMReg());
+        int_args += 2;
       } else {
-        regs[i].set2(VMRegImpl::stack2reg(stk_args));
+        if (stk_args & 1) stk_args++;
+        regs[i].set_pair(VMRegImpl::stack2reg(stk_args + 1), VMRegImpl::stack2reg(stk_args));
+        int_args = Argument::n_int_register_parameters_j;
         stk_args += 2;
       }
-      break;
     case T_FLOAT:
       if (fp_args < Argument::n_float_register_parameters_j) {
         regs[i].set1(FP_ArgReg[fp_args++]->as_VMReg());
@@ -312,7 +312,8 @@ int SharedRuntime::java_calling_convention(const BasicType *sig_bt,
     }
   }
 
-  return align_up(stk_args, 2);
+  if (stk_args & 1) stk_args++;
+  return stk_args;
 }
 
 // Patch the callers callsite with entry to compiled code if it exists.
@@ -658,7 +659,7 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
 
   uint int_args = 0;
   uint fp_args = 0;
-  uint stk_args = 0; // inc by 2 each time
+  uint stk_args = 0;
 
   for (int i = 0; i < total_args_passed; i++) {
     switch (sig_bt[i]) {
@@ -667,27 +668,31 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
     case T_BYTE:
     case T_SHORT:
     case T_INT:
-      if (int_args < Argument::n_int_register_parameters_c) {
-        regs[i].set1(INT_ArgReg[int_args++]->as_VMReg());
-      } else {
-        regs[i].set1(VMRegImpl::stack2reg(stk_args));
-        stk_args += 2;
-      }
-      break;
-    case T_LONG:
-      assert((i + 1) < total_args_passed && sig_bt[i + 1] == T_VOID, "expecting half");
-      // fall through
-    case T_OBJECT:
     case T_ARRAY:
+    case T_OBJECT:
     case T_ADDRESS:
     case T_METADATA:
       if (int_args < Argument::n_int_register_parameters_c) {
-        regs[i].set2(INT_ArgReg[int_args++]->as_VMReg());
+        regs[i].set1(INT_ArgReg[int_args++]->as_VMReg());
       } else {
-        regs[i].set2(VMRegImpl::stack2reg(stk_args));
-        stk_args += 2;
+        regs[i].set1(VMRegImpl::stack2reg(stk_args++));
       }
       break;
+    case T_LONG:
+      if (int_args < Argument::n_int_register_parameters_c - 1) {
+        if (int_args & 1) int_args++;
+        regs[i].set_pair(INT_ArgReg[int_args + 1]->as_VMReg(), INT_ArgReg[int_args]->as_VMReg());
+        int_args += 2;
+      } else if (int_args == Argument::n_int_register_parameters_c - 1){
+        regs[i].set_pair(VMRegImpl::stack2reg(stk_args), INT_ArgReg[int_args]->as_VMReg());
+        int_args = Argument::n_int_register_parameters_c;
+        stk_args += 1;
+      } else {
+        if (stk_args & 1) stk_args++;
+        regs[i].set_pair(VMRegImpl::stack2reg(stk_args + 1), VMRegImpl::stack2reg(stk_args));
+        int_args = Argument::n_int_register_parameters_c;
+        stk_args += 2;
+      }
     case T_FLOAT:
       if (fp_args < Argument::n_float_register_parameters_c) {
         regs[i].set1(FP_ArgReg[fp_args++]->as_VMReg());
@@ -862,21 +867,63 @@ static void float_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
 // A long move
 static void long_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
   assert_cond(masm != NULL);
-  if (src.first()->is_stack()) {
-    if (dst.first()->is_stack()) {
-      // stack to stack
+  if (dst.second()->is_Register()) {
+    if (src.second()->is_Register()) {
+      // <R,R> -> <R,R>
+      assert(dst.first()->is_Register() && src.first()->is_Register(), "must be");
+      __ mv(dst.first()->as_Register(), src.first()->as_Register());
+      __ mv(dst.second()->as_Register(), src.second()->as_Register());
+    } else if (src.first()->is_Register()) {
+      // <R,stack> -> <R,R>
+      assert(dst.first()->is_Register() && src.second()->is_stack(), "must be");
+      __ mv(dst.first()->as_Register(), src.first()->as_Register());
+      __ lw(dst.second()->as_Register(), Address(fp, reg2offset_in(src.second())));
+    } else {
+      // <stack,stack> -> <R,R>
+      assert(dst.first()->is_Register() && src.first()->is_stack() && src.second()->is_stack(), "must be");
+      __ lw(dst.first()->as_Register(), Address(fp, reg2offset_in(src.first())));
+      __ lw(dst.second()->as_Register(), Address(fp, reg2offset_in(src.second())));
+    }
+  } else if (src.second()->is_Register()) {
+    if (dst.first()->is_Register()) {
+      // <R,R> -> <R,stack>
+      assert(dst.second()->is_stack() && src.first()->is_Register(), "must be");
+      __ mv(dst.first()->as_Register(), src.first()->as_Register());
+      __ sw(src.second()->as_Register(), Address(sp, reg2offset_out(dst.second())));
+    } else {
+      // <R,R> -> <stack,stack>
+      assert(dst.first()->is_stack() && dst.second()->is_stack() && src.first()->is_Register(), "must be");
+      __ sw(src.first()->as_Register(), Address(sp, reg2offset_out(dst.first())));
+      __ sw(src.second()->as_Register(), Address(sp, reg2offset_out(dst.second())));
+    }
+  } else if (src.first()->is_Register()) {
+    if (dst.first()->is_Register()) {
+      // <R,stack> -> <R,stack>
+      assert(dst.second()->is_stack() && src.second()->is_stack(), "must be");
+      __ mv(dst.first()->as_Register(), src.first()->as_Register());
+      __ lw(t0, Address(fp, reg2offset_in(src.second())));
+      __ sw(t0, Address(sp, reg2offset_out(dst.second())));
+    } else {
+      // <R,stack> -> <stack,stack>
+      assert(dst.first()->is_stack() && dst.second()->is_stack() && src.second()->is_stack(), "must be");
+      __ sw(src.first()->as_Register(), Address(sp, reg2offset_out(dst.first())));
+      __ lw(t0, Address(fp, reg2offset_in(src.second())));
+      __ sw(t0, Address(sp, reg2offset_out(dst.second())));
+    }
+  } else {
+    if (dst.first()->is_Register()) {
+      // <stack,stack> -> <R,stack>
+      assert(dst.second()->is_stack() && src.first()->is_stack() && src.second()->is_stack(), "must be");
+      __ lw(dst.first()->as_Register(), Address(fp, reg2offset_in(src.first())));
+      __ lw(t0, Address(fp, reg2offset_in(src.second())));
+      __ sw(t0, Address(sp, reg2offset_out(dst.second())));
+    } else {
+      // <stack,stack> -> <stack,stack>
+      assert(dst.first()->is_stack() && dst.second()->is_stack() && src.first()->is_stack() && src.second()->is_stack(), "must be");
       __ lw(t0, Address(fp, reg2offset_in(src.first())));
       __ sw(t0, Address(sp, reg2offset_out(dst.first())));
-    } else {
-      // stack to reg
-      __ lw(dst.first()->as_Register(), Address(fp, reg2offset_in(src.first())));
-    }
-  } else if (dst.first()->is_stack()) {
-    // reg to stack
-    __ sw(src.first()->as_Register(), Address(sp, reg2offset_out(dst.first())));
-  } else {
-    if (dst.first() != src.first()) {
-      __ mv(dst.first()->as_Register(), src.first()->as_Register());
+      __ lw(t0, Address(fp, reg2offset_in(src.second())));
+      __ sw(t0, Address(sp, reg2offset_out(dst.second())));
     }
   }
 }
@@ -890,10 +937,15 @@ static void double_move(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
     if (dst.first()->is_stack()) {
       __ lw(t0, Address(fp, reg2offset_in(src.first())));
       __ sw(t0, Address(sp, reg2offset_out(dst.first())));
+      __ lw(t0, Address(fp, reg2offset_in(src.second())));
+      __ sw(t0, Address(sp, reg2offset_out(dst.second())));
     } else if (dst.first()-> is_Register()) {
       __ lw(dst.first()->as_Register(), Address(fp, reg2offset_in(src.first())));
+      __ lw(dst.second()->as_Register(), Address(fp, reg2offset_in(src.second())));
     } else {
-      ShouldNotReachHere();
+      __ lw(dst.first()->as_Register(), Address(fp, reg2offset_in(src.first())));
+      __ lw(t0, Address(fp, reg2offset_in(src.second())));
+      __ sw(t0, Address(sp, reg2offset_out(dst.second())));
     }
   } else if (src.first() != dst.first()) {
     if (src.is_single_phys_reg() && dst.is_single_phys_reg()) {
@@ -916,6 +968,8 @@ void SharedRuntime::save_native_result(MacroAssembler *masm, BasicType ret_type,
     __ fsd(f10, Address(fp, -2 * wordSize));
     break;
   case T_VOID:  break;
+  case T_LONG:
+    __ sw(x11, Address(fp, -2*wordSize));
   default: {
     __ sw(x10, Address(fp, -wordSize));
     }
@@ -934,6 +988,8 @@ void SharedRuntime::restore_native_result(MacroAssembler *masm, BasicType ret_ty
     __ fld(f10, Address(fp, - 2 * wordSize));
     break;
   case T_VOID:  break;
+  case T_LONG:
+    __ lw(x11, Address(fp, -2*wordSize));
   default: {
     __ lw(x10, Address(fp, -wordSize));
     }

--- a/src/hotspot/cpu/riscv32/vmreg_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/vmreg_riscv32.hpp
@@ -37,7 +37,7 @@ inline bool is_FloatRegister() {
 
 inline Register as_Register() {
   assert( is_Register(), "must be");
-  return ::as_Register(value() >> 1);
+  return ::as_Register(value());
 }
 
 inline FloatRegister as_FloatRegister() {

--- a/src/hotspot/cpu/riscv32/vmreg_riscv32.inline.hpp
+++ b/src/hotspot/cpu/riscv32/vmreg_riscv32.inline.hpp
@@ -31,7 +31,7 @@ inline VMReg RegisterImpl::as_VMReg() {
   if( this == noreg ) {
     return VMRegImpl::Bad();
   }
-  return VMRegImpl::as_VMReg(encoding() << 1);
+  return VMRegImpl::as_VMReg(encoding());
 }
 
 inline VMReg FloatRegisterImpl::as_VMReg() {


### PR DESCRIPTION
* In rv32 the size of the slot is 32 bits, so there is no need to shift left in register_riscv32.xxx. At the same time, max_slots_per_register, which is the number of slots in each register, also needs to be modified, 2 for 64 bits and 1 for 32 bits.

* 'max_gpr' will cause problems caused by halving the number of rv32 integer registers in ConcreteRegister, so it also needs to be adjusted.

* In 'java_calling_convention' and 'c_calling_convention', referring to the implementation of arm32 and x86_32, the minimum value of slot (stk_args) is changed to 1, and the logic of T_LONG/T_INT is modified, which has no effect on the current result.

* In 'long_move' and 'double_nove', add processing of data stored in registers and stacks respectively.

* In 'save_native_result' and 'restore_native_result', add the processing of T_LONG.