### PR TITLE
Fix the return value on ic_stub_code_size()

### DIFF
--- a/src/hotspot/cpu/riscv32/icBuffer_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/icBuffer_riscv32.cpp
@@ -35,9 +35,9 @@
 #include "oops/oop.inline.hpp"
 
 int InlineCacheBuffer::ic_stub_code_size() {
-  // 6: auipc + lw + auipc + jalr + address(2 * instruction_size)
-  // 5: auipc + lw + j + address(2 * instruction_size )
-  return (MacroAssembler::far_branches() ? 6 : 5) * NativeInstruction::instruction_size;
+  // 5: auipc + lw + auipc + jalr + address(1 * instruction_size)
+  // 4: auipc + lw + j + address(1 * instruction_size )
+  return (MacroAssembler::far_branches() ? 5 : 4) * NativeInstruction::instruction_size;
 }
 
 #define __ masm->


### PR DESCRIPTION
In RV64, the address length is 8 bytes, and since instruction_size has a value of 4, you need multiplied by. In Rv32, instead of multiplying by 2, the corresponding return value of 6 is 5, and 5 is 4..