### PR TITLE
Fix offset in MacroAssembler::zero_words()

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -4175,7 +4175,7 @@ void MacroAssembler::zero_words(Register ptr, Register cnt)
     beqz(t0, l);
     for (int j = 0; j < i; j++) {
       sw(zr, Address(ptr, 0));
-      addi(ptr, ptr, 8);
+      addi(ptr, ptr, wordSize);
     }
     bind(l);
   }


### PR DESCRIPTION
MacroAssembler::zero_words() has a 8 bit offset, it must same with the wordsize. The
wordsize of rv32g is 4, so use the wordsize instead of the 8.