### PR TITLE
Fix loadl instruct

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -4133,10 +4133,12 @@ instruct loadL(iRegLNoSp dst, memory mem)
   match(Set dst (LoadL mem));
 
   ins_cost(LOAD_COST);
-  format %{ "lw  $dst, $mem\t# int, #@loadL" %}
+  format %{ "lw    $dst.lo, $mem\n\t"
+            "lw    $dst.hi, $mem+4\t# int, #@loadL" %}
 
   ins_encode %{
     __ lw(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
+    __ lw(as_Register($dst$$reg)->successor(), Address(as_Register($mem$$base), $mem$$disp+4));
   %}
 
   ins_pipe(iload_reg_mem);

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -4133,8 +4133,8 @@ instruct loadL(iRegLNoSp dst, memory mem)
   match(Set dst (LoadL mem));
 
   ins_cost(LOAD_COST * 2);
-  format %{ "lw    $dst.lo, $mem\n\t"
-            "lw    $dst.hi, $mem+4\t# int, #@loadL" %}
+  format %{ "lw  $dst.lo, $mem\n\t"
+            "lw  $dst.hi, $mem+4\t# int, #@loadL" %}
 
   ins_encode %{
     __ lw(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -4132,7 +4132,7 @@ instruct loadL(iRegLNoSp dst, memory mem)
 %{
   match(Set dst (LoadL mem));
 
-  ins_cost(LOAD_COST);
+  ins_cost(LOAD_COST * 2);
   format %{ "lw    $dst.lo, $mem\n\t"
             "lw    $dst.hi, $mem+4\t# int, #@loadL" %}
 


### PR DESCRIPTION
Since long data requires two registers to load in RISCV32, it needs to be modified in riscv32.ad.
