### PR TITLE
Fix MacroAssembler::zero_words failed to clear memory completely

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -4173,18 +4173,19 @@ void MacroAssembler::zero_words(Register ptr, Register cnt)
     Label l;
     andi(t0, cnt, i);
     beqz(t0, l);
-    for (int j = 0; j < i; j++) {
+    for (int j = 0; j < 2 * i; j++) {
       sw(zr, Address(ptr, 0));
       addi(ptr, ptr, wordSize);
     }
     bind(l);
   }
   {
-    Label l;
+    Label label;
     andi(t0, cnt, 1);
-    beqz(t0, l);
+    beqz(t0, label);
     sw(zr, Address(ptr, 0));
-    bind(l);
+    sw(zr, Address(ptr, wordSize));
+    bind(label);
   }
   BLOCK_COMMENT("} zero_words");
 }

--- a/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/stubGenerator_riscv32.cpp
@@ -620,9 +620,9 @@ class StubGenerator: public StubCodeGenerator {
       __ sub(cnt, cnt, MacroAssembler::zero_words_block_size);
       __ bltz(cnt, done);
       __ bind(loop);
-      for (int i = 0; i < MacroAssembler::zero_words_block_size; i++) {
+      for (int i = 0; i < 2 * MacroAssembler::zero_words_block_size; i++) {
         __ sw(zr, Address(base, 0));
-        __ add(base, base, 8);
+        __ add(base, base, wordSize);
       }
       __ sub(cnt, cnt, MacroAssembler::zero_words_block_size);
       __ bgez(cnt, loop);


### PR DESCRIPTION
Co-authored-by: Ningning Shi(史宁宁) <shiningning@iscas.ac.cn>