### PR TITLE
Fix orL_reg_reg in riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -7030,15 +7030,14 @@ instruct andL_reg_imm(iRegLNoSp dst, iRegL src1, immLAdd src2) %{
 instruct orL_reg_reg(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   match(Set dst (OrL src1 src2));
 
-  format %{ "orr  $dst, $src1, $src2\t#@orL_reg_reg" %}
+  format %{ "orr  $dst.lo, $src1.lo, $src2.lo\n\t"
+            "orr  $dst.hi, $src1.hi, $src2.hi\t#@orL_reg_reg" %}
 
-  ins_cost(ALU_COST);
+  ins_cost(ALU_COST * 2);
   ins_encode %{
-    __ orr(as_Register($dst$$reg),
-           as_Register($src1$$reg),
-           as_Register($src2$$reg));
+    __ orr(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
+    __ orr(as_Register($dst$$reg)->successor(), as_Register($src1$$reg)->successor(), as_Register($src2$$reg)->successor());
   %}
-
   ins_pipe(ialu_reg_reg);
 %}
 


### PR DESCRIPTION
Refer to the RV32 interpreter. When performing ORL operations on long data, it is necessary to perform ORL operations on high-order registers and low-order registers respectively.