### PR TITLE
Fix xorL_reg_reg in riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -7062,13 +7062,13 @@ instruct orL_reg_imm(iRegLNoSp dst, iRegL src1, immLAdd src2) %{
 instruct xorL_reg_reg(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   match(Set dst (XorL src1 src2));
 
-  format %{ "xorr  $dst, $src1, $src2\t#@xorL_reg_reg" %}
+  format %{ "xorr  $dst.lo, $src1.lo, $src2.lo\n\t"
+            "xorr  $dst.hi, $src1.hi, $src2.hi\t#@xorL_reg_reg" %}
 
-  ins_cost(ALU_COST);
+  ins_cost(ALU_COST * 2);
   ins_encode %{
-    __ xorr(as_Register($dst$$reg),
-            as_Register($src1$$reg),
-            as_Register($src2$$reg));
+    __ xorr(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
+    __ xorr(as_Register($dst$$reg)->successor(), as_Register($src1$$reg)->successor(), as_Register($src2$$reg)->successor());
   %}
 
   ins_pipe(ialu_reg_reg);


### PR DESCRIPTION
In RISCV32, long registers need to perform XORL operations on high and low registers respectively