### PR TITLE
Fix orL_reg_imm in riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -7046,13 +7046,13 @@ instruct orL_reg_reg(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 instruct orL_reg_imm(iRegLNoSp dst, iRegL src1, immLAdd src2) %{
   match(Set dst (OrL src1 src2));
 
-  format %{ "ori  $dst, $src1, $src2\t#@orL_reg_imm" %}
+  format %{ "ori  $dst.lo, $src1.lo, $src2\n\t"
+            "ori  $dst.hi, $src1.hi, 0\t#@orL_reg_imm" %}
 
-  ins_cost(ALU_COST);
+  ins_cost(ALU_COST * 2);
   ins_encode %{
-    __ ori(as_Register($dst$$reg),
-           as_Register($src1$$reg),
-           (int32_t)($src2$$constant));
+    __ ori(as_Register($dst$$reg), as_Register($src1$$reg), (int32_t)($src2$$constant));
+    __ ori(as_Register($dst$$reg)->successor(), as_Register($src1$$reg)->successor(), 0);       
   %}
 
   ins_pipe(ialu_reg_imm);


### PR DESCRIPTION
In RISCV32, the ORL operation of long register and long immediate register requires orL operation of high register and low register respectively.