### PR TITLE
Fix addI_reg_imm_l2i/convL2I_reg in riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -5977,7 +5977,7 @@ instruct addI_reg_imm_l2i(iRegINoSp dst, iRegL src1, immIAdd src2) %{
   match(Set dst (AddI (ConvL2I src1) src2));
 
   ins_cost(ALU_COST);
-  format %{ "addi  $dst, $src1, $src2\t#@addI_reg_imm_l2i" %}
+  format %{ "addi  $dst, $src1.lo, $src2\t#@addI_reg_imm_l2i" %}
 
   ins_encode %{
     __ addi(as_Register($dst$$reg),
@@ -7369,7 +7369,7 @@ instruct convL2I_reg(iRegINoSp dst, iRegL src) %{
   match(Set dst (ConvL2I src));
 
   ins_cost(ALU_COST);
-  format %{ "add  $dst, $src, zr\t#@convL2I_reg" %}
+  format %{ "add  $dst, $src.lo, zr\t#@convL2I_reg" %}
 
   ins_encode %{
     __ add(as_Register($dst$$reg), as_Register($src$$reg), zr);


### PR DESCRIPTION
In addI_reg_imm_l2i/convL2I_reg, only `src1.lo` is in use.