### PR TITLE
Fix loadI2L/loadUI2L

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -4100,11 +4100,13 @@ instruct loadI2L(iRegLNoSp dst, memory mem)
 %{
   match(Set dst (ConvI2L (LoadI mem)));
 
-  ins_cost(LOAD_COST);
-  format %{ "lw  $dst, $mem\t# int, #@loadI2L" %}
+  ins_cost(LOAD_COST + ALU_COST);
+  format %{ "lw    $dst.lo, $mem\n\t"
+            "srai  $dst.hi, dst.lo, 0x1f\t# int, #@loadI2L" %}
 
   ins_encode %{
     __ lw(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
+    __ srai(as_Register($dst$$reg)->successor(), as_Register($dst$$reg), 0x1f);
   %}
 
   ins_pipe(iload_reg_mem);
@@ -4115,11 +4117,13 @@ instruct loadUI2L(iRegLNoSp dst, memory mem, immL_32bits mask)
 %{
   match(Set dst (AndL (ConvI2L (LoadI mem)) mask));
 
-  ins_cost(LOAD_COST);
-  format %{ "lw  $dst, $mem\t# int, #@loadUI2L" %}
+  ins_cost(LOAD_COST + ALU_COST);
+  format %{ "lw  $dst.lo, $mem\n\t"
+            "mv  $dst.hi, 0\t# int, #@loadUI2L" %}
 
   ins_encode %{
     __ lw(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
+    __ mv(as_Register($dst$$reg)->successor(), 0);
   %}
 
   ins_pipe(iload_reg_mem);


### PR DESCRIPTION
Co-authored-by: Dingli Zhang <dingli@iscas.ac.cn>
High 32 bit should be zero in loadUI2l/loadI2L，and consider the sign bit in loadI2L.

