### PR TITLE
Update the movptr condition and data dependency

### DIFF
--- a/src/hotspot/cpu/riscv32/nativeInst_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/nativeInst_riscv32.cpp
@@ -70,7 +70,12 @@ bool NativeInstruction::is_li_at(address instr) {
 }
 
 bool NativeInstruction::is_movptr_at(address instr) {
-  return is_li_at(instr);
+  if (is_lui_at(instr) && // lui
+      (is_addi_at(instr + 4) || is_jalr_at(instr + 4) || is_load_at(instr + 4)) && // addi/jalr/load
+      check_movptr_data_dependency(instr)) {
+    return true;
+  }
+  return false;
 }
 
 void NativeCall::verify() {

--- a/src/hotspot/cpu/riscv32/nativeInst_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/nativeInst_riscv32.hpp
@@ -100,6 +100,13 @@ class NativeInstruction {
            compare_instr_field(instr + 4, 19, 15, instr + 4, 11, 7);   // check the rs1 field and the rd field of addi
   }
 
+  // the instruction sequence of movptr is as below:
+  //     lui
+  //     addi/jalr/load
+  static bool check_movptr_data_dependency(address instr) {
+    return compare_instr_field(instr + 4, 19, 15, instr, 11, 7);      // check the rs1 field of addi/jalr/load and the rd field of lui
+  }
+
   // the instruction sequence of pc-relative is as below:
   //     auipc
   //     jalr/addi/load/float_load


### PR DESCRIPTION
The movptr condition is not as same as the insns in movtpr(), so update it according the
rv64g.

The movprt data dependency is also need to update, it is not same with li.