### PR TITLE
Add T_LONG for save/restore_native_result

### DIFF
--- a/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/sharedRuntime_riscv32.cpp
@@ -929,6 +929,10 @@ void SharedRuntime::save_native_result(MacroAssembler *masm, BasicType ret_type,
     __ fsd(f10, Address(fp, -2 * wordSize));
     break;
   case T_VOID:  break;
+  case T_LONG:
+    __ lw(x11, Address(fp, -2 * wordSize));
+    __ lw(x10, Address(fp, -wordSize));
+    break;
   default: {
     __ sw(x10, Address(fp, -wordSize));
     }
@@ -944,9 +948,13 @@ void SharedRuntime::restore_native_result(MacroAssembler *masm, BasicType ret_ty
     __ flw(f10, Address(fp, -wordSize));
     break;
   case T_DOUBLE:
-    __ fld(f10, Address(fp, - 2 * wordSize));
+    __ fld(f10, Address(fp, -2 * wordSize));
     break;
   case T_VOID:  break;
+  case T_LONG:
+    __ lw(x11, Address(fp, -2 * wordSize));
+    __ lw(x10, Address(fp, -wordSize));
+    break;
   default: {
     __ lw(x10, Address(fp, -wordSize));
     }


### PR DESCRIPTION
The long of rv32g need to use two register, so need to add T_LONG and code for long in
save/restore_native_result.