### PR TITLE
Fix the bug of regname

### DIFF
--- a/src/hotspot/cpu/riscv32/vmreg_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/vmreg_riscv32.cpp
@@ -33,7 +33,6 @@ void VMRegImpl::set_regName() {
   int i = 0;
   for ( ; i < ConcreteRegisterImpl::max_gpr ; ) {
     regName[i++] = reg->name();
-    regName[i++] = reg->name();
     reg = reg->successor();
   }
 


### PR DESCRIPTION
The int reg are 32, but the regName still set as 64, it need to delete a
regeName inst in for.