### PR TITLE
change the relationship between j_rargx and c_rargx

### DIFF
--- a/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/assembler_riscv32.hpp
@@ -69,14 +69,14 @@ REGISTER_DECLARATION(FloatRegister, c_farg6, f16);
 REGISTER_DECLARATION(FloatRegister, c_farg7, f17);
 
 // java function register(caller-save registers)
-REGISTER_DECLARATION(Register, j_rarg0, c_rarg1);
-REGISTER_DECLARATION(Register, j_rarg1, c_rarg2);
-REGISTER_DECLARATION(Register, j_rarg2, c_rarg3);
-REGISTER_DECLARATION(Register, j_rarg3, c_rarg4);
-REGISTER_DECLARATION(Register, j_rarg4, c_rarg5);
-REGISTER_DECLARATION(Register, j_rarg5, c_rarg6);
-REGISTER_DECLARATION(Register, j_rarg6, c_rarg7);
-REGISTER_DECLARATION(Register, j_rarg7, c_rarg0);
+REGISTER_DECLARATION(Register, j_rarg0, c_rarg0);
+REGISTER_DECLARATION(Register, j_rarg1, c_rarg1);
+REGISTER_DECLARATION(Register, j_rarg2, c_rarg2);
+REGISTER_DECLARATION(Register, j_rarg3, c_rarg3);
+REGISTER_DECLARATION(Register, j_rarg4, c_rarg4);
+REGISTER_DECLARATION(Register, j_rarg5, c_rarg5);
+REGISTER_DECLARATION(Register, j_rarg6, c_rarg6);
+REGISTER_DECLARATION(Register, j_rarg7, c_rarg7);
 
 REGISTER_DECLARATION(FloatRegister, j_farg0, f10);
 REGISTER_DECLARATION(FloatRegister, j_farg1, f11);


### PR DESCRIPTION
The int reg don't have the reg like R1_H, so the next of R16 must R17. The j_rarg7 is c_rarg0,
it is the x10, but the j_rarg6 is c_rarg7 which is x17. The list can't be right in the next(),
so change the java function registers.