### PR TITLE
Fix the loadConL in riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -1720,6 +1720,14 @@ encode %{
     __ li(dst_reg, con);
   %}
 
+  enc_class riscv32_enc_li_imm_long(iRegIorL dst, immL src) %{
+    MacroAssembler _masm(&cbuf);
+    int32_t con = (int32_t)$src$$constant;
+    Register dst_reg = as_Register($dst$$reg);
+    __ li(dst_reg, con);
+    __ li(dst_reg->successor(), 0);
+  %}
+
   enc_class riscv32_enc_mov_p(iRegP dst, immP src) %{
     MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
@@ -4280,8 +4288,7 @@ instruct loadConL(iRegLNoSp dst, immL src)
   ins_cost(ALU_COST);
   format %{ "li $dst, $src\t# long, #@loadConL" %}
 
-  ins_encode(riscv32_enc_li_imm(dst, src));
-
+  ins_encode(riscv32_enc_li_imm_long(dst, src));
   ins_pipe(ialu_imm);
 %}
 


### PR DESCRIPTION
The loadConl will load a long imm, but the rv32g just can give a 32bit
data, so it need to set 0 int the high reg.