### PR TITLE
improve the div system

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1838,13 +1838,13 @@ int MacroAssembler::corrected_idiv(Register result, Register ra, Register rb,
   //         remainder (= ra irem rb)
 
 
-  int idivl_offset = offset();
+  int idiv_offset = offset();
   if (!want_remainder) {
     div(result, ra, rb);
   } else {
     rem(result , ra, rb); // result = ra % rb;
   }
-  return idivl_offset;
+  return idiv_offset;
 }
 
 // Look up the method for a megamorpic invkkeinterface call.

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1823,7 +1823,7 @@ void MacroAssembler::store_heap_oop_null(Address dst) {
   access_store_at(T_OBJECT, IN_HEAP, dst, noreg, noreg, noreg);
 }
 
-int MacroAssembler::corrected_idivl(Register result, Register ra, Register rb,
+int MacroAssembler::corrected_idiv(Register result, Register ra, Register rb,
                                     bool want_remainder)
 {
   // Full implementation of Java idiv and irem.  The function
@@ -1845,29 +1845,6 @@ int MacroAssembler::corrected_idivl(Register result, Register ra, Register rb,
     rem(result , ra, rb); // result = ra % rb;
   }
   return idivl_offset;
-}
-
-int MacroAssembler::corrected_idivq(Register result, Register ra, Register rb,
-                                    bool want_remainder)
-{
-  // Full implementation of Java ldiv and lrem.  The function
-  // returns the (pc) offset of the div instruction - may be needed
-  // for implicit exceptions.
-  //
-  // input : ra: dividend
-  //         rb: divisor
-  //
-  // result: either
-  //         quotient  (= ra idiv rb)
-  //         remainder (= ra irem rb)
-
-  int idivq_offset = offset();
-  if (!want_remainder) {
-    div(result, ra, rb);
-  } else {
-    rem(result , ra, rb); // result = ra % rb;
-  }
-  return idivq_offset;
 }
 
 // Look up the method for a megamorpic invkkeinterface call.

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -231,9 +231,7 @@ class MacroAssembler: public Assembler {
   static bool needs_explicit_null_check(intptr_t offset);
 
   // idiv variant which deals with MINLONG as dividend and -1 as divisor
-  int corrected_idivl(Register result, Register ra, Register rb,
-                      bool want_remainder);
-  int corrected_idivq(Register result, Register ra, Register rb,
+  int corrected_idiv(Register result, Register ra, Register rb,
                       bool want_remainder);
 
   // interface method calling

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -2163,15 +2163,7 @@ encode %{
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
-    __ corrected_idivq(dst_reg, src1_reg, src2_reg, false);
-  %}
-
-  enc_class riscv32_enc_modw(iRegI dst, iRegI src1, iRegI src2) %{
-    MacroAssembler _masm(&cbuf);
-    Register dst_reg = as_Register($dst$$reg);
-    Register src1_reg = as_Register($src1$$reg);
-    Register src2_reg = as_Register($src2$$reg);
-    __ corrected_idivl(dst_reg, src1_reg, src2_reg, true);
+    __ corrected_idiv(dst_reg, src1_reg, src2_reg, false);
   %}
 
   enc_class riscv32_enc_mod(iRegI dst, iRegI src1, iRegI src2) %{
@@ -2179,7 +2171,7 @@ encode %{
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
-    __ corrected_idivq(dst_reg, src1_reg, src2_reg, true);
+    __ corrected_idiv(dst_reg, src1_reg, src2_reg, true);
   %}
 
   enc_class riscv32_enc_tail_call(iRegP jump_target) %{
@@ -6326,7 +6318,7 @@ instruct modI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   ins_cost(IDIVSI_COST);
   format %{ "remw  $dst, $src1, $src2\t#@modI" %}
 
-  ins_encode(riscv32_enc_modw(dst, src1, src2));
+  ins_encode(riscv32_enc_mod(dst, src1, src2));
   ins_pipe(ialu_reg_reg);
 %}
 

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -1443,7 +1443,7 @@ void TemplateTable::idiv()
   __ bind(no_div0);
   __ pop_i(x11);
   // x10 <== x11 idiv x10
-  __ corrected_idivl(x10, x11, x10, /* want_remainder */ false);
+  __ corrected_idiv(x10, x11, x10, /* want_remainder */ false);
 }
 
 void TemplateTable::irem()
@@ -1457,7 +1457,7 @@ void TemplateTable::irem()
   __ bind(no_div0);
   __ pop_i(x11);
   // x10 <== x11 irem x10
-  __ corrected_idivl(x10, x11, x10, /* want_remainder */ true);
+  __ corrected_idiv(x10, x11, x10, /* want_remainder */ true);
 }
 
 void TemplateTable::lmul()


### PR DESCRIPTION
The code of div system need to improve, then we need to build a new div system for rv32g.
In rv32g div system, the int data use the div/rem, the long data need to deal with more
calcute insts.

This patch will clean the code, and delete some code we will not need. This patch will not
change the result of any type div.