### PR TITLE
fix the divL/modL in riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1847,6 +1847,36 @@ int MacroAssembler::corrected_idiv(Register result, Register ra, Register rb,
   return idiv_offset;
 }
 
+void MacroAssembler::ldiv(Register result, Register ra, Register rb)
+{
+  orr(t1, ra, ra->successor());
+  assert(t1 != 0, "div 0");
+  call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::ldiv), ra, ra->successor(), rb, rb->successor());
+  mv(result, ra);
+  mv(result->successor(), ra->successor());
+}
+
+void MacroAssembler::lrem(Register result, Register ra, Register rb)
+{
+  orr(t1, ra, ra->successor());
+  assert(t1 != 0, "div 0");
+  call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::lrem), ra, ra->successor(), rb, rb->successor());
+  mv(result, ra);
+  mv(result->successor(), ra->successor());
+}
+
+int MacroAssembler::corrected_ldiv(Register result, Register ra, Register rb,
+                                    bool want_remainder)
+{
+  int ldiv_offset = offset();
+  if (!want_remainder) {
+    ldiv(result, ra, rb);
+  } else {
+    lrem(result , ra, rb); // result = ra % rb;
+  }
+  return ldiv_offset;
+}
+
 // Look up the method for a megamorpic invkkeinterface call.
 // The target method is determined by <intf_klass, itable_index>.
 // The receiver klass is in recv_klass.

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -233,6 +233,10 @@ class MacroAssembler: public Assembler {
   // idiv variant which deals with MINLONG as dividend and -1 as divisor
   int corrected_idiv(Register result, Register ra, Register rb,
                       bool want_remainder);
+  void ldiv(Register result, Register ra, Register rb);
+  void lrem(Register result, Register ra, Register rb);
+  int corrected_ldiv(Register result, Register ra, Register rb,
+                                    bool want_remainder);
 
   // interface method calling
   void lookup_interface_method(Register recv_klass,

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -2166,12 +2166,28 @@ encode %{
     __ corrected_idiv(dst_reg, src1_reg, src2_reg, false);
   %}
 
+  enc_class riscv32_enc_div_long(iRegI dst, iRegI src1, iRegI src2) %{
+    MacroAssembler _masm(&cbuf);
+    Register dst_reg = as_Register($dst$$reg);
+    Register src1_reg = as_Register($src1$$reg);
+    Register src2_reg = as_Register($src2$$reg);
+    __ corrected_ldiv(dst_reg, src1_reg, src2_reg, false);
+  %}
+
   enc_class riscv32_enc_mod(iRegI dst, iRegI src1, iRegI src2) %{
     MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
     __ corrected_idiv(dst_reg, src1_reg, src2_reg, true);
+  %}
+
+  enc_class riscv32_enc_mod_long(iRegI dst, iRegI src1, iRegI src2) %{
+    MacroAssembler _masm(&cbuf);
+    Register dst_reg = as_Register($dst$$reg);
+    Register src1_reg = as_Register($src1$$reg);
+    Register src2_reg = as_Register($src2$$reg);
+    __ corrected_ldiv(dst_reg, src1_reg, src2_reg, true);
   %}
 
   enc_class riscv32_enc_tail_call(iRegP jump_target) %{
@@ -6296,7 +6312,7 @@ instruct divL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   ins_cost(IDIVDI_COST);
   format %{ "div  $dst, $src1, $src2\t#@divL" %}
 
-  ins_encode(riscv32_enc_div(dst, src1, src2));
+  ins_encode(riscv32_enc_div_long(dst, src1, src2));
   ins_pipe(ldiv_reg_reg);
 %}
 
@@ -6329,7 +6345,7 @@ instruct modL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   ins_cost(IDIVDI_COST);
   format %{ "rem  $dst, $src1, $src2\t#@modL" %}
 
-  ins_encode(riscv32_enc_mod(dst, src1, src2));
+  ins_encode(riscv32_enc_mod_long(dst, src1, src2));
   ins_pipe(ialu_reg_reg);
 %}
 


### PR DESCRIPTION
The divL and modL in riscv32.ad need to deal, because the long in rv32g
is 64bit, and it use the two regs.