### PR TITLE
Fix the compareAndExchangeLAcq()

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -5277,6 +5277,8 @@ instruct compareAndExchangeLAcq(iRegLNoSp res, indirect mem, iRegL oldval, iRegL
   ins_encode %{
     __ cmpxchg(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int32,
                /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register);
+    __ cmpxchg(as_Register($mem$$base)->successor(), $oldval$$Register->successor(), $newval$$Register->successor(), Assembler::int32,
+               /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register->successor());
   %}
 
   ins_pipe(pipe_slow);


### PR DESCRIPTION
The compareAndExchangeLAcq() is same with the compareAndExchangeL(), except
use the Assembler::aq instead of the Assembler::relaxed.
So this patch fix the compareAndExchangeLAcq() followed the compareAndExchangeL().