### PR TITLE
Fix the weakCompareAndSwapLAcq

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -5536,7 +5536,7 @@ instruct weakCompareAndSwapLAcq(iRegINoSp res, indirect mem, iRegL oldval, iRegL
 
   match(Set res (WeakCompareAndSwapL mem (Binary oldval newval)));
 
-  ins_cost(LOAD_COST + STORE_COST + BRANCH_COST * 2 + ALU_COST * 2);
+  ins_cost(LOAD_COST * 2 + STORE_COST * 2 + BRANCH_COST * 4 + ALU_COST * 5);
 
   format %{
     "cmpxchg_weak_acq $mem, $oldval, $newval\t# (long, weak) if $mem == $oldval then $mem <-- $newval\n\t"
@@ -5546,7 +5546,11 @@ instruct weakCompareAndSwapLAcq(iRegINoSp res, indirect mem, iRegL oldval, iRegL
   ins_encode %{
     __ cmpxchg_weak(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int32,
                /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register);
+    __ cmpxchg_weak(as_Register($mem$$base)->successor(), $oldval$$Register->successor(), $newval$$Register->successor(), Assembler::int32,
+               /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register->successor());
     __ xori($res$$Register, $res$$Register, 1);
+    __ xori($res$$Register->successor(), $res$$Register->successor(), 1);
+    __ andr($res$$Register, $res$$Register, $res$$Register->successor());
   %}
 
   ins_pipe(pipe_slow);


### PR DESCRIPTION
The weakCompareAndSwapLAcq is same with the weakCompareAndSwapL, except the
different of Assembler::aq.