### PR TITLE
Improve the xchg system

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -2332,22 +2332,9 @@ void MacroAssembler::atomic_##OP(Register prev, Register newv, Register addr) { 
 }
 
 ATOMIC_XCHG(xchg, amoswap_w, Assembler::relaxed, Assembler::relaxed)
-ATOMIC_XCHG(xchgw, amoswap_w, Assembler::relaxed, Assembler::relaxed)
 ATOMIC_XCHG(xchgal, amoswap_w, Assembler::aq, Assembler::rl)
-ATOMIC_XCHG(xchgalw, amoswap_w, Assembler::aq, Assembler::rl)
 
 #undef ATOMIC_XCHG
-
-#define ATOMIC_XCHGU(OP1, OP2)                                                       \
-void MacroAssembler::atomic_##OP1(Register prev, Register newv, Register addr) {     \
-  atomic_##OP2(prev, newv, addr);                                                    \
-  return;                                                                            \
-}
-
-ATOMIC_XCHGU(xchgwu, xchgw)
-ATOMIC_XCHGU(xchgalwu, xchgalw)
-
-#undef ATOMIC_XCHGU
 
 void MacroAssembler::biased_locking_exit(Register obj_reg, Register temp_reg, Label& done, Register flag) {
   assert(UseBiasedLocking, "why call this otherwise?");

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -4834,7 +4834,7 @@ instruct storeIConditional(indirect mem, iRegINoSp oldval, iRegINoSp newval, rFl
   ins_cost(LOAD_COST + STORE_COST + BRANCH_COST * 2);
 
   format %{
-    "cmpxchgw t1, $mem, $oldval, $newval, $mem\t# if $mem == $oldval then $mem <-- $newval"
+    "cmpxchg t1, $mem, $oldval, $newval, $mem\t# if $mem == $oldval then $mem <-- $newval"
     "xorr $cr, $cr, $oldval\t# $cr == 0 on successful write, #@storeIConditional"
   %}
 
@@ -5606,7 +5606,7 @@ instruct get_and_setI(indirect mem, iRegI newv, iRegINoSp prev)
 
   ins_cost(ALU_COST);
 
-  format %{ "atomic_xchgw  $prev, $newv, [$mem]\t#@get_and_setI" %}
+  format %{ "atomic_xchg  $prev, $newv, [$mem]\t#@get_and_setI" %}
 
   ins_encode %{
     __ atomic_xchg($prev$$Register, $newv$$Register, as_Register($mem$$base));
@@ -5637,10 +5637,10 @@ instruct get_and_setN(indirect mem, iRegN newv, iRegINoSp prev)
 
   ins_cost(ALU_COST);
 
-  format %{ "atomic_xchgwu $prev, $newv, [$mem]\t#@get_and_setN" %}
+  format %{ "atomic_xchg $prev, $newv, [$mem]\t#@get_and_setN" %}
 
   ins_encode %{
-    __ atomic_xchgwu($prev$$Register, $newv$$Register, as_Register($mem$$base));
+    __ atomic_xchg($prev$$Register, $newv$$Register, as_Register($mem$$base));
   %}
 
   ins_pipe(pipe_serial);
@@ -5669,7 +5669,7 @@ instruct get_and_setIAcq(indirect mem, iRegI newv, iRegINoSp prev)
 
   ins_cost(ALU_COST);
 
-  format %{ "atomic_xchgw_acq  $prev, $newv, [$mem]\t#@get_and_setIAcq" %}
+  format %{ "atomic_xchg_acq  $prev, $newv, [$mem]\t#@get_and_setIAcq" %}
 
   ins_encode %{
     __ atomic_xchgal($prev$$Register, $newv$$Register, as_Register($mem$$base));
@@ -5704,10 +5704,10 @@ instruct get_and_setNAcq(indirect mem, iRegN newv, iRegINoSp prev)
 
   ins_cost(ALU_COST);
 
-  format %{ "atomic_xchgwu_acq $prev, $newv, [$mem]\t#@get_and_setNAcq" %}
+  format %{ "atomic_xchg_acq $prev, $newv, [$mem]\t#@get_and_setNAcq" %}
 
   ins_encode %{
-    __ atomic_xchgalwu($prev$$Register, $newv$$Register, as_Register($mem$$base));
+    __ atomic_xchgal($prev$$Register, $newv$$Register, as_Register($mem$$base));
   %}
 
   ins_pipe(pipe_serial);


### PR DESCRIPTION
 Some xchg funcs are not need in rv32g, delete them to improve the code quality.