### PR TITLE
Remove the lShiftL_regI_immGE32

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -6066,19 +6066,6 @@ instruct addP_reg_reg(iRegPNoSp dst, iRegP src1, iRegI src2) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-// If we shift more than 32 bits, we need not convert I2L.
-instruct lShiftL_regI_immGE32(iRegLNoSp dst, iRegIorL2I src, uimmI6_ge32 scale) %{
-  match(Set dst (LShiftL (ConvI2L src) scale));
-  ins_cost(ALU_COST);
-  format %{ "slli  $dst, $src, $scale & 0x1f\t#@lShiftL_regI_immGE32" %}
-
-  ins_encode %{
-    __ slli(as_Register($dst$$reg), as_Register($src$$reg), $scale$$constant & 0x1f);
-  %}
-
-  ins_pipe(ialu_reg_shift);
-%}
-
 // Pointer Immediate Addition
 // n.b. this needs to be more expensive than using an indirect memory
 // operand


### PR DESCRIPTION
The lShiftL_regI_immGE32 instruct is no need in rv32g, so remove it.