### PR TITLE
Fix the mulHiL_rReg

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -6288,13 +6288,16 @@ instruct mulL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 instruct mulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2)
 %{
   match(Set dst (MulHiL src1 src2));
-  ins_cost(IMUL_COST);
+  ins_cost(IMUL_COST * 4 + ALU_COST * 2);
   format %{ "mulh  $dst, $src1, $src2\t# mulhi, #@mulHiL_rReg" %}
 
   ins_encode %{
-    __ mulh(as_Register($dst$$reg),
-            as_Register($src1$$reg),
-            as_Register($src2$$reg));
+   __ mul(as_Register($src2$$reg)->successor(),as_Register($src2$$reg)->successor(),as_Register($src1$$reg));
+   __ mul(as_Register($src1$$reg)->successor(),as_Register($src1$$reg)->successor(),as_Register($src2$$reg));
+   __ mulhu(t0,as_Register($src1$$reg),as_Register($src2$$reg));
+   __ add(as_Register($dst$$reg)->successor(),as_Register($src1$$reg)->successor(),as_Register($src2$$reg)->successor());
+   __ add(as_Register($dst$$reg)->successor(),as_Register($dst$$reg)->successor(),t0);
+   __ mv(as_Register($dst$$reg), as_Register($dst$$reg)->successor());
   %}
 
   ins_pipe(lmul_reg_reg);


### PR DESCRIPTION
The mulHiL_rReg need to mul two long data, and save the high 32-bit data into dst.
The mulHiL_rReg code is according the mulL.