### PR TITLE
Fix the signExtractL

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -6339,7 +6339,7 @@ instruct signExtractL(iRegLNoSp dst, iRegL src1, immI_63 div1, immI_63 div2) %{
   format %{ "srli $dst, $src1, $div1\t# long signExtract, #@signExtractL" %}
 
   ins_encode %{
-    __ srli(as_Register($dst$$reg), as_Register($src1$$reg), 63);
+    __ srli(as_Register($dst$$reg), as_Register($src1$$reg)->successor(), 31);
   %}
   ins_pipe(ialu_reg_shift);
 %}


### PR DESCRIPTION
signExtractL need to srli 63, so just need the high 32bit srli 31, then save the result
into the dst.