### PR TITLE
Fix the urShiftL_reg_reg/imm

### DIFF
--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1900,6 +1900,29 @@ void MacroAssembler::lShiftL_reg_reg(Register dst, Register src1, Register src2)
     return;
 }
 
+void MacroAssembler::urShiftL_reg_reg(Register dst, Register src1, Register src2)
+{
+    andi(src2, src2, 0x3f);
+
+    Label blt_branch,done;
+    addi(t0, src2, -32);
+    bltz(t0, blt_branch);
+    srl(dst, src1->successor(), t0);
+    mv(dst->successor(), 0);
+    beqz(zr, done);
+    bind(blt_branch);
+    mv(t0, 31);
+    slli(t1, src1->successor(), 0x1);
+    sub(t0, t0, src2);
+    sll(t1, t1, t0);
+    srl(dst, src1, src2);
+    orr(dst, t1, dst);
+    srl(dst->successor(), src1->successor(), src2);
+
+    bind(done);
+    return;
+}
+
 // Look up the method for a megamorpic invkkeinterface call.
 // The target method is determined by <intf_klass, itable_index>.
 // The receiver klass is in recv_klass.

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -238,6 +238,7 @@ class MacroAssembler: public Assembler {
   int corrected_ldiv(Register result, Register ra, Register rb,
                      bool want_remainder);
   void lShiftL_reg_reg(Register dst, Register src1, Register src2);
+  void urShiftL_reg_reg(Register dst, Register src1, Register src2);
 
   // interface method calling
   void lookup_interface_method(Register recv_klass,

--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -2216,6 +2216,24 @@ encode %{
     __ lShiftL_reg_reg(dst_reg, src1_reg, shift_reg);
   %}
 
+ enc_class riscv32_enc_urShiftL_reg_reg(iRegI dst, iRegI src1, iRegI src2)%{
+    MacroAssembler _masm(&cbuf);
+    Register dst_reg = as_Register($dst$$reg);
+    Register src1_reg = as_Register($src1$$reg);
+    Register src2_reg = as_Register($src2$$reg);
+    __ urShiftL_reg_reg(dst_reg, src1_reg, src2_reg);
+  %}
+
+   enc_class riscv32_enc_urShiftL_reg_imm(iRegI dst, iRegI src1, immI src2)%{
+    MacroAssembler _masm(&cbuf);
+    Register dst_reg = as_Register($dst$$reg);
+    Register src1_reg = as_Register($src1$$reg);
+    Register shift_reg = NULL;
+    int32_t con = (int32_t)$src2$$constant;
+    __ addi(shift_reg, zr, con);
+    __ urShiftL_reg_reg(dst_reg, src1_reg, shift_reg);
+  %}
+
   enc_class riscv32_enc_tail_call(iRegP jump_target) %{
     MacroAssembler _masm(&cbuf);
     Register target_reg = as_Register($jump_target$$reg);
@@ -6498,14 +6516,10 @@ instruct lShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
 instruct urShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (URShiftL src1 src2));
 
-  ins_cost(ALU_COST);
+  ins_cost(ALU_COST * 12 + BRANCH_COST * 2);
   format %{ "srl  $dst, $src1, $src2\t#@urShiftL_reg_reg" %}
 
-  ins_encode %{
-    __ srl(as_Register($dst$$reg),
-            as_Register($src1$$reg),
-            as_Register($src2$$reg));
-  %}
+  ins_encode(riscv32_enc_urShiftL_reg_reg(dst, src1, src2));
 
   ins_pipe(ialu_reg_reg_vshift);
 %}
@@ -6514,16 +6528,12 @@ instruct urShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
 instruct urShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
   match(Set dst (URShiftL src1 src2));
 
-  ins_cost(ALU_COST);
+  ins_cost(ALU_COST * 12 + BRANCH_COST * 2);
   format %{ "srli  $dst, $src1, ($src2 & 0x3f)\t#@urShiftL_reg_imm" %}
 
-  ins_encode %{
-    // the shift amount is encoded in the lower
-    // 6 bits of the I-immediate field for RV32I
-    __ srli(as_Register($dst$$reg),
-            as_Register($src1$$reg),
-            (unsigned) $src2$$constant & 0x3f);
-  %}
+  // the shift amount is encoded in the lower
+  // 6 bits of the I-immediate field for RV32
+  ins_encode(riscv32_enc_urShiftL_reg_imm(dst, src1, src2));
 
   ins_pipe(ialu_reg_shift);
 %}


### PR DESCRIPTION
The urShiftL_reg_reg/imm need to srl a long data from 0 to 64. This need to do more operation in rv32g.