### PR TITLE
Refactor the grevw system

### DIFF
--- a/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/interp_masm_riscv32.cpp
@@ -181,7 +181,7 @@ void InterpreterMacroAssembler::check_and_handle_earlyret(Register java_thread) 
 void InterpreterMacroAssembler::get_unsigned_2_byte_index_at_bcp(Register reg, int bcp_offset) {
   assert(bcp_offset >= 0, "bcp is still pointing to start of bytecode");
   lhu(reg, Address(xbcp, bcp_offset));
-  grev16(reg, reg);
+  grev16w(reg, reg);
 }
 
 void InterpreterMacroAssembler::get_dispatch() {

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.cpp
@@ -1402,18 +1402,6 @@ void MacroAssembler::grev16w(Register Rd, Register Rs, Register Rtmp1, Register 
   assert_different_registers(Rs, Rtmp1, Rtmp2);
   assert_different_registers(Rd, Rtmp1, Rtmp2);
   srli(Rtmp2, Rs, 16);
-  grevh(Rtmp2, Rtmp2, Rtmp1);
-  grevhu(Rd, Rs, Rtmp1);
-  slli(Rtmp2, Rtmp2, 16);
-  orr(Rd, Rd, Rtmp2);
-}
-
-void MacroAssembler::grev16wu(Register Rd, Register Rs, Register Rtmp1, Register Rtmp2) {
-  // Reverse bytes in half-word (32bit)
-  // Rd[31:0] = Rs[23:16] Rs[31:24] Rs[7:0] Rs[15:8]
-  assert_different_registers(Rs, Rtmp1, Rtmp2);
-  assert_different_registers(Rd, Rtmp1, Rtmp2);
-  srli(Rtmp2, Rs, 16);
   grevhu(Rtmp2, Rtmp2, Rtmp1);
   grevhu(Rd, Rs, Rtmp1);
   slli(Rtmp2, Rtmp2, 16);
@@ -1425,41 +1413,7 @@ void MacroAssembler::grevw(Register Rd, Register Rs, Register Rtmp1, Register Rt
   // Rd[31:0] = Rs[7:0] Rs[15:8] Rs[23:16] Rs[31:24]
   assert_different_registers(Rs, Rtmp1, Rtmp2);
   assert_different_registers(Rd, Rtmp1, Rtmp2);
-  grev16wu(Rd, Rs, Rtmp1, Rtmp2);
-  slli(Rtmp2, Rd, 16);
-  srli(Rd, Rd, 16);
-  orr(Rd, Rd, Rtmp2);
-}
-
-void MacroAssembler::grevwu(Register Rd, Register Rs, Register Rtmp1, Register Rtmp2) {
-  // Reverse bytes in word (32bit)
-  // Rd[31:0] = Rs[7:0] Rs[15:8] Rs[23:16] Rs[31:24]
-  assert_different_registers(Rs, Rtmp1, Rtmp2);
-  assert_different_registers(Rd, Rtmp1, Rtmp2);
-  grev16wu(Rd, Rs, Rtmp1, Rtmp2);
-  slli(Rtmp2, Rd, 16);
-  srli(Rd, Rd, 16);
-  orr(Rd, Rd, Rtmp2);
-}
-
-void MacroAssembler::grev16(Register Rd, Register Rs, Register Rtmp1, Register Rtmp2) {
-  // Reverse bytes in half-word (32bit)
-  // Rd[31:0] = Rs[23:16] Rs[31:24] Rs[7:0] Rs[15:8]
-  assert_different_registers(Rs, Rtmp1, Rtmp2);
-  assert_different_registers(Rd, Rtmp1, Rtmp2);
-  srli(Rtmp2, Rs, 16);
-  grevhu(Rtmp2, Rtmp2, Rtmp1);
-  grevhu(Rd, Rs, Rtmp1);
-  slli(Rtmp2, Rtmp2, 16);
-  orr(Rd, Rd, Rtmp2);
-}
-
-void MacroAssembler::grev32(Register Rd, Register Rs, Register Rtmp1, Register Rtmp2) {
-  // Reverse bytes in word (32bit)
-  // Rd[31:0] = Rs[7:0] Rs[15:8] Rs[23:16] Rs[31:24]
-  assert_different_registers(Rs, Rtmp1, Rtmp2);
-  assert_different_registers(Rd, Rtmp1, Rtmp2);
-  grev16wu(Rd, Rs, Rtmp1, Rtmp2);
+  grev16w(Rd, Rs, Rtmp1, Rtmp2);
   slli(Rtmp2, Rd, 16);
   srli(Rd, Rd, 16);
   orr(Rd, Rd, Rtmp2);

--- a/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
+++ b/src/hotspot/cpu/riscv32/macroAssembler_riscv32.hpp
@@ -503,14 +503,9 @@ class MacroAssembler: public Assembler {
 
   // grev
   void grevh(Register Rd, Register Rs, Register Rtmp = t0);                            // basic reverse bytes in 16-bit halfwords, sign-extend
-  void grev16w(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);    // reverse bytes in 16-bit halfwords(32), sign-extend
-  void grevw(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);      // reverse bytes(32), sign-extend
-  void grev16(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2= t1);      // reverse bytes in 16-bit halfwords
-  void grev32(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2= t1);      // reverse bytes in 32-bit words
   void grevhu(Register Rd, Register Rs, Register Rtmp = t0);                           // basic reverse bytes in 16-bit halfwords, zero-extend
-  void grev16wu(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);   // reverse bytes in 16-bit halfwords(32), zero-extend
-  void grevwu(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);     // reverse bytes(32), zero-extend
-
+  void grev16w(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);    // reverse bytes in 16-bit halfwords(32)
+  void grevw(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);      // reverse bytes(32)
 
   void andi(Register Rd, Register Rn, int32_t increment, Register temp = t0);
   void orptr(Address adr, RegisterOrConstant src, Register tmp1 = t0, Register tmp2 = t1);

--- a/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
+++ b/src/hotspot/cpu/riscv32/templateTable_riscv32.cpp
@@ -1689,7 +1689,7 @@ void TemplateTable::wide_iinc()
 {
   transition(vtos, vtos);
   __ lw(x11, at_bcp(2)); // get constant and index
-  __ grev16wu(x11, x11); // reverse bytes in half-word (32bit) and zero-extend
+  __ grev16w(x11, x11); // reverse bytes in half-word (32bit) and zero-extend
   __ zero_ext(x12, x11, 16);
   __ neg(x12, x12);
   __ srai(x11, x11, 16);
@@ -2226,7 +2226,7 @@ void TemplateTable::fast_linearswitch() {
   __ andi(x9, x9, -BytesPerInt);
   // set counter
   __ lw(x11, Address(x9, BytesPerInt));
-  __ grev32(x11, x11);
+  __ grevw(x11, x11);
   __ j(loop_entry);
   // table search
   __ bind(loop);
@@ -2302,7 +2302,7 @@ void TemplateTable::fast_binaryswitch() {
   __ lw(j, Address(array, -BytesPerInt)); // j = length(array)
 
   // Convert j into native byteordering
-  __ grev32(j, j);
+  __ grevw(j, j);
 
   // And start
   Label entry;


### PR DESCRIPTION
The grevw system of rv64 are too complex for rv32g, some functions can be deleted.
This patch refactor the grevw system to fit the rv32g.