### PR TITLE
Improve the compareAndSwapL/compareAndSwapLAcq

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -1838,13 +1838,9 @@ encode %{
 
   enc_class riscv32_enc_cmpxchgl(iRegINoSp res, memory mem, iRegLNoSp oldval, iRegLNoSp newval) %{
     MacroAssembler _masm(&cbuf);
-    __ cmpxchg(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int32,
-               /*acquire*/ Assembler::relaxed, /*release*/ Assembler::rl, $res$$Register,
-               /*result as bool*/ true);
-    __ cmpxchg(as_Register($mem$$base)->successor(), $oldval$$Register->successor(), $newval$$Register->successor(), Assembler::int32,
-               /*acquire*/ Assembler::relaxed, /*release*/ Assembler::rl, $res$$Register->successor(),
-               /*result as bool*/ true);
-    __ andr($res$$Register,  $res$$Register, $res$$Register->successor());
+    __ cmpxchg_long(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int32,
+                   /*acquire*/ Assembler::relaxed, /*release*/ Assembler::rl, $res$$Register,
+                   /*result as bool*/ true);
   %}
 
   enc_class riscv32_enc_cmpxchgb_acq(iRegINoSp res, memory mem, iRegI_R12 oldval, iRegI_R13 newval, iRegI tmp1, iRegI tmp2, iRegI tmp3) %{
@@ -1877,13 +1873,9 @@ encode %{
 
   enc_class riscv32_enc_cmpxchgl_acq(iRegINoSp res, memory mem, iRegLNoSp oldval, iRegLNoSp newval) %{
     MacroAssembler _masm(&cbuf);
-    __ cmpxchg(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int32,
-               /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register,
-               /*result as bool*/ true);
-    __ cmpxchg(as_Register($mem$$base)->successor(), $oldval$$Register->successor(), $newval$$Register->successor(), Assembler::int32,
-               /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register->successor(),
-               /*result as bool*/ true);
-    __ andr($res$$Register,  $res$$Register, $res$$Register->successor());
+    __ cmpxchg_long(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int32,
+                    /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register,
+                    /*result as bool*/ true);
   %}
 
   // compare and branch instruction encodings


### PR DESCRIPTION
Use the cmpxchg_long to instead of the twice cmpxchg.