### PR TITLE
Fix the RFLAGS in riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -202,10 +202,10 @@ reg_def F31_H ( SOC, SOC, Op_RegF,  31, f31->as_VMReg()->next() );
 // Special Registers
 // ----------------------------
 
-// On riscv, the physical flag register is missing, so we use t1 instead,
+// On riscv, the physical flag register is missing, so we use t0 instead,
 // to bridge the RegFlag semantics in share/opto
 
-reg_def RFLAGS   (SOC, SOC, Op_RegFlags, 6, x6->as_VMReg());
+reg_def RFLAGS   (SOC, SOC, Op_RegFlags, 5, x5->as_VMReg());
 
 // Specify priority of register selection within phases of register
 // allocation.  Highest priority is first.  A useful heuristic is to
@@ -1924,12 +1924,12 @@ encode %{
 
   // call instruction encodings
 
-  enc_class riscv32_enc_partial_subtype_check(iRegP sub, iRegP super, iRegP temp, iRegP result) %{
+  enc_class riscv32_enc_partial_subtype_check(iRegP sub, iRegP super, iRegP temp, iRegP result, rFlagsReg cr) %{
     Register sub_reg = as_Register($sub$$reg);
     Register super_reg = as_Register($super$$reg);
     Register temp_reg = as_Register($temp$$reg);
     Register result_reg = as_Register($result$$reg);
-    Register cr_reg = t1;
+    Register cr_reg = as_Register($cr$$reg);
 
     Label miss;
     Label done;
@@ -2027,9 +2027,9 @@ encode %{
   %}
 
   // using the cr register as the bool result: 0 for success; others failed.
-  enc_class riscv32_enc_fast_lock(iRegP object, iRegP box, iRegP tmp, iRegP tmp2) %{
+  enc_class riscv32_enc_fast_lock(rFlagsReg cr, iRegP object, iRegP box, iRegP tmp, iRegP tmp2) %{
     MacroAssembler _masm(&cbuf);
-    Register flag = t1;
+    Register flag = as_Register($cr$$reg);
     Register oop = as_Register($object$$reg);
     Register box = as_Register($box$$reg);
     Register disp_hdr = as_Register($tmp$$reg);
@@ -2115,9 +2115,9 @@ encode %{
   %}
 
   // using cr flag to indicate the fast_unlock result: 0 for success; others failed.
-  enc_class riscv32_enc_fast_unlock(iRegP object, iRegP box, iRegP tmp, iRegP tmp2) %{
+  enc_class riscv32_enc_fast_unlock(rFlagsReg cr, iRegP object, iRegP box, iRegP tmp, iRegP tmp2) %{
     MacroAssembler _masm(&cbuf);
-    Register flag = t1;
+    Register flag = as_Register($cr$$reg);
     Register oop = as_Register($object$$reg);
     Register box = as_Register($box$$reg);
     Register disp_hdr = as_Register($tmp$$reg);
@@ -9426,7 +9426,7 @@ instruct partialSubtypeCheck(rFlagsReg cr, iRegP_R14 sub, iRegP_R10 super, iRegP
   ins_cost(2 * STORE_COST + 3 * LOAD_COST + 4 * ALU_COST + BRANCH_COST * 4);
   format %{ "partialSubtypeCheck $result, $sub, $super\t#@partialSubtypeCheck" %}
 
-  ins_encode(riscv32_enc_partial_subtype_check(sub, super, temp, result));
+  ins_encode(riscv32_enc_partial_subtype_check(sub, super, temp, result, cr));
 
   opcode(0x1); // Force zero of result reg on hit
 
@@ -9442,7 +9442,7 @@ instruct partialSubtypeCheckVsZero(iRegP_R14 sub, iRegP_R10 super, iRegP_R12 tem
   ins_cost(2 * STORE_COST + 3 * LOAD_COST + 4 * ALU_COST + BRANCH_COST * 4);
   format %{ "partialSubtypeCheck $result, $sub, $super == 0\t#@partialSubtypeCheckVsZero" %}
 
-  ins_encode(riscv32_enc_partial_subtype_check(sub, super, temp, result));
+  ins_encode(riscv32_enc_partial_subtype_check(sub, super, temp, result, cr));
 
   opcode(0x0); // Don't zero result reg on hit
 
@@ -9790,7 +9790,7 @@ instruct cmpFastLock(rFlagsReg cr, iRegP object, iRegP box, iRegPNoSp tmp, iRegP
   ins_cost(LOAD_COST * 2 + STORE_COST * 3 + ALU_COST * 6 + BRANCH_COST * 3);
   format %{ "fastlock $object,$box\t! kills $tmp,$tmp2, #@cmpFastLock" %}
 
-  ins_encode(riscv32_enc_fast_lock(object, box, tmp, tmp2));
+  ins_encode(riscv32_enc_fast_lock(cr, object, box, tmp, tmp2));
 
   ins_pipe(pipe_serial);
 %}
@@ -9804,7 +9804,7 @@ instruct cmpFastUnlock(rFlagsReg cr, iRegP object, iRegP box, iRegPNoSp tmp, iRe
   ins_cost(LOAD_COST * 2 + STORE_COST + ALU_COST * 2 + BRANCH_COST * 4);
   format %{ "fastunlock $object,$box\t! kills $tmp, $tmp2, #@cmpFastUnlock" %}
 
-  ins_encode(riscv32_enc_fast_unlock(object, box, tmp, tmp2));
+  ins_encode(riscv32_enc_fast_unlock(cr, object, box, tmp, tmp2));
 
   ins_pipe(pipe_serial);
 %}


### PR DESCRIPTION
The RFLAGS sometimes need to store the long data, so it need to use the x5. Some RFLAGS be instead of t1, they are not incorrect.