### PR TITLE
Fix the RegisterImpl::number_of_registers in riscv32.ad

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -1103,9 +1103,9 @@ static enum RC rc_class(OptoReg::Name reg) {
     return rc_bad;
   }
 
-  // we have 30 int registers * 2 halves
+  // we have 32 int registers * 1 halves
   // (t0 and t1 are omitted)
-  int slots_of_int_registers = RegisterImpl::max_slots_per_register * (RegisterImpl::number_of_registers - 2);
+  int slots_of_int_registers = RegisterImpl::max_slots_per_register * RegisterImpl::number_of_registers;
   if (reg < slots_of_int_registers) {
     return rc_int;
   }


### PR DESCRIPTION
The RegisterImpl::number_of_registers don't need to - 2, because it will not change in riscv32.ad, it is always 32.