### PR TITLE
Fix the loadL according the arm 32bit

### DIFF
--- a/src/hotspot/cpu/riscv32/riscv32.ad
+++ b/src/hotspot/cpu/riscv32/riscv32.ad
@@ -4331,7 +4331,7 @@ instruct loadUI2L(iRegLNoSp dst, memory mem, immL_32bits mask)
   ins_pipe(iload_reg_mem);
 %}
 
-// Load Long (32 bit signed)
+// Load Long (64 bit signed)
 instruct loadL(iRegLNoSp dst, memory mem)
 %{
   match(Set dst (LoadL mem));
@@ -4341,8 +4341,13 @@ instruct loadL(iRegLNoSp dst, memory mem)
             "lw  $dst.hi, $mem+4\t# int, #@loadL" %}
 
   ins_encode %{
-    __ lw(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
-    __ lw(as_Register($dst$$reg)->successor(), Address(as_Register($mem$$base), $mem$$disp+4));
+    if (as_Register($dst$$reg) == as_Register($mem$$base)) {
+      __ lw(as_Register($dst$$reg)->successor(), Address(as_Register($mem$$base), $mem$$disp + 4));
+      __ lw(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
+    } else {
+      __ lw(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
+      __ lw(as_Register($dst$$reg)->successor(), Address(as_Register($mem$$base), $mem$$disp + 4));
+    }
   %}
 
   ins_pipe(iload_reg_mem);


### PR DESCRIPTION
If the dst is same with the mem, it need to store the hi 32bit data. It can avoid the data been rewrite.